### PR TITLE
Implement typed DSL parser

### DIFF
--- a/dsl/__init__.py
+++ b/dsl/__init__.py
@@ -1,0 +1,6 @@
+
+"""DSL parsing and compilation utilities."""
+
+from .parser import TrainModel, compile_sql, parse
+
+__all__ = ["TrainModel", "parse", "compile_sql"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+lark


### PR DESCRIPTION
## Summary
- enhance DSL parser with typed parameter handling
- export parser utilities from `dsl` package
- use JSON encoding for compiled SQL
- add lark to requirements

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853309fac0c8328894a636de27fc6df