### PR TITLE
Fix SQL string building

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -94,14 +94,16 @@ def compile_sql(model: TrainModel) -> str:
     feature_cols = ", ".join(model.features)
     params_dict = {k: v for k, v in model.params}
     params_json = json.dumps(params_dict)
+    training_query = f"SELECT {feature_cols}, {model.target} FROM {model.source}"
+    feature_array = ", ".join(repr(f) for f in model.features)
     sql = (
         "SELECT ml_train_model("
-        f"model_name := '{model.name}', "
-        f"algorithm := '{model.algorithm}', "
-        f"algorithm_params := '{params_json}', "
-        f"training_data := 'SELECT {feature_cols}, {model.target} FROM {model.source}', "
-        f"target_column := '{model.target}', "
-        f"feature_columns := ARRAY[{', '.join([f'\'{f}\'' for f in model.features])}]"
+        f"model_name := {repr(model.name)}, "
+        f"algorithm := {repr(model.algorithm)}, "
+        f"algorithm_params := {repr(params_json)}, "
+        f"training_data := {repr(training_query)}, "
+        f"target_column := {repr(model.target)}, "
+        f"feature_columns := ARRAY[{feature_array}]"
         ")"
     )
     return sql


### PR DESCRIPTION
## Summary
- use repr to safely quote names and parameters in `compile_sql`

## Testing
- `python -m py_compile dsl/parser.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853321a820c83289975c5a484e8917b