### PR TITLE
Fix unused import in tests

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,6 +1,5 @@
 import os
 import re
-import glob
 
 DOC_FILES = [
     'README.md',


### PR DESCRIPTION
## Summary
- clean up `tests/test_docs.py` by removing unused `glob` import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853321b37b48328bab52199f6a4e35f