### PR TITLE
Update algorithm parsing

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -11,7 +11,9 @@ dsl_grammar = r"""
 
 train_stmt: "TRAIN" "MODEL" NAME "USING" algorithm "FROM" NAME "PREDICT" NAME features
 
-algorithm: NAME "(" param_list? ")"
+# The algorithm specification can be either just a name or
+# a name followed by an optional parenthesized parameter list.
+algorithm: NAME ["(" param_list? ")"]
 param_list: param ("," param)*
 param: NAME "=" value
 value: NUMBER | ESCAPED_STRING | NAME
@@ -59,7 +61,10 @@ class TreeToModel(Transformer):
 
     def algorithm(self, items):
         alg_name = items[0]
-        params = items[1] if len(items) > 1 else []
+        if len(items) == 1 or items[1] is None:
+            params = []
+        else:
+            params = items[1]
         return alg_name, params
 
     def feature_list(self, items):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -21,5 +21,18 @@ class TestParser(unittest.TestCase):
         sql = parser.compile_sql(model)
         self.assertIn("ml_train_model", sql)
 
+    def test_parse_train_model_no_params(self):
+        text = (
+            "TRAIN MODEL simple_model USING decision_tree FROM training_data "
+            "PREDICT outcome WITH FEATURES(a, b)"
+        )
+        model = parser.parse(text)
+        self.assertEqual(model.name, "simple_model")
+        self.assertEqual(model.algorithm, "decision_tree")
+        self.assertEqual(model.params, [])
+        self.assertEqual(model.source, "training_data")
+        self.assertEqual(model.target, "outcome")
+        self.assertEqual(model.features, ["a", "b"])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow algorithms without parameter lists in DSL grammar
- handle missing parameters in transformer
- test parser with and without algorithm parameters

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853321bdf708328820440a52b69646e