### PR TITLE
Add parser support for algorithm without params

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -11,7 +11,7 @@ dsl_grammar = r"""
 
 train_stmt: "TRAIN" "MODEL" NAME "USING" algorithm "FROM" NAME "PREDICT" NAME features
 
-algorithm: NAME "(" param_list? ")"
+algorithm: NAME ("(" param_list? ")")?
 param_list: param ("," param)*
 param: NAME "=" value
 value: NUMBER | ESCAPED_STRING | NAME

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -21,5 +21,18 @@ class TestParser(unittest.TestCase):
         sql = parser.compile_sql(model)
         self.assertIn("ml_train_model", sql)
 
+    def test_parse_train_model_no_params(self):
+        text = (
+            "TRAIN MODEL x USING logistic_regression FROM data "
+            "PREDICT y WITH FEATURES(a)"
+        )
+        model = parser.parse(text)
+        self.assertEqual(model.name, "x")
+        self.assertEqual(model.algorithm, "logistic_regression")
+        self.assertEqual(model.params, [])
+        self.assertEqual(model.source, "data")
+        self.assertEqual(model.target, "y")
+        self.assertEqual(model.features, ["a"])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow DSL algorithm specification without parentheses
- test parsing of algorithms without parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853321bccbc83288f6be8d900313494