### PR TITLE
Add CLI for DSL compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ When code becomes available:
 Install the Python dependencies with `pip install -r requirements.txt` and then
 run `pytest` from the repository root to verify the test suite passes.
 
+### CLI Usage
+
+The repository includes a simple command line interface for compiling DSL files
+into SQL. You can provide a file path or pipe DSL text via standard input:
+
+```bash
+# From a file
+python -m dsl.cli path/to/model.dsl
+
+# From stdin
+echo "TRAIN MODEL example USING decision_tree FROM data PREDICT y WITH FEATURES(x)" | \
+    python -m dsl.cli
+```
+
 See `AGENTS.md` for more on our autonomous approach to managing the project.
 
 ## Architecture Documents

--- a/dsl/__init__.py
+++ b/dsl/__init__.py
@@ -2,5 +2,6 @@
 """DSL parsing and compilation utilities."""
 
 from .parser import TrainModel, compile_sql, parse
+from . import cli
 
-__all__ = ["TrainModel", "parse", "compile_sql"]
+__all__ = ["TrainModel", "parse", "compile_sql", "cli"]

--- a/dsl/cli.py
+++ b/dsl/cli.py
@@ -1,0 +1,32 @@
+import argparse
+import sys
+
+from .parser import parse, compile_sql
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Compile DeclarativeML DSL to SQL."""
+    parser = argparse.ArgumentParser(
+        description="Compile DeclarativeML DSL to SQL"
+    )
+    parser.add_argument(
+        "source",
+        nargs="?",
+        help="Path to DSL file. Reads from stdin if omitted.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.source:
+        with open(args.source, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    else:
+        text = sys.stdin.read()
+
+    model = parse(text)
+    sql = compile_sql(model)
+    sys.stdout.write(sql)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import subprocess
+import unittest
+
+class TestCLI(unittest.TestCase):
+    def test_cli_stdin(self):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        dsl_text = (
+            "TRAIN MODEL cli_model USING decision_tree FROM data "
+            "PREDICT label WITH FEATURES(x, y)"
+        )
+        result = subprocess.run(
+            [sys.executable, "-m", "dsl.cli"],
+            input=dsl_text.encode(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=repo_root,
+            check=True,
+        )
+        output = result.stdout.decode()
+        self.assertIn("ml_train_model", output)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a simple CLI under `dsl/cli.py` for compiling DSL text to SQL
- expose CLI in `dsl/__init__.py`
- document CLI usage in README
- add unit test for the CLI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853341fe3008328b7468d833a540fc9