### PR TITLE
Add parser error handling tests with hypothesis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 lark
+hypothesis

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,6 +5,8 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from dsl import parser
+from lark.exceptions import LarkError
+from hypothesis import given, strategies as st
 
 class TestParser(unittest.TestCase):
     def test_parse_train_model(self):
@@ -33,6 +35,40 @@ class TestParser(unittest.TestCase):
         self.assertEqual(model.source, "training_data")
         self.assertEqual(model.target, "outcome")
         self.assertEqual(model.features, ["a", "b"])
+
+    def test_invalid_syntax_raises(self):
+        with self.assertRaises(LarkError):
+            parser.parse("TRAIN MODEL bad USING algo FROM tbl")
+
+    def test_missing_features_clause(self):
+        text = "TRAIN MODEL m USING a FROM t PREDICT y"
+        with self.assertRaises(LarkError):
+            parser.parse(text)
+
+    def test_algorithm_param_types(self):
+        text = (
+            "TRAIN MODEL m USING alg(num=1, rate=0.5, name=\"x\") FROM t "
+            "PREDICT y WITH FEATURES(a)"
+        )
+        model = parser.parse(text)
+        self.assertEqual(model.params, [("num", 1), ("rate", 0.5), ("name", "x")])
+
+
+@given(
+    model_name=st.text(min_size=1, alphabet=st.characters(min_codepoint=97, max_codepoint=122)),
+    algorithm=st.text(min_size=1, alphabet=st.characters(min_codepoint=97, max_codepoint=122)),
+    source=st.text(min_size=1, alphabet=st.characters(min_codepoint=97, max_codepoint=122)),
+    target=st.text(min_size=1, alphabet=st.characters(min_codepoint=97, max_codepoint=122)),
+    feature=st.text(min_size=1, alphabet=st.characters(min_codepoint=97, max_codepoint=122))
+)
+def test_property_based_parse(model_name, algorithm, source, target, feature):
+    text = (
+        f"TRAIN MODEL {model_name} USING {algorithm} FROM {source} "
+        f"PREDICT {target} WITH FEATURES({feature})"
+    )
+    model = parser.parse(text)
+    assert model.name == model_name
+    assert model.algorithm == algorithm
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `hypothesis` dependency
- extend parser tests with error cases
- verify param type parsing
- add property-based test for random DSL strings

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685334207e488328b16464adec3d6cc4