### PR TITLE
Extend DSL parser with training options

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, List
+from typing import Any, Dict, List, Optional
 
 from lark import Lark, Transformer, v_args
 
@@ -9,7 +9,7 @@ from lark import Lark, Transformer, v_args
 dsl_grammar = r"""
 ?start: train_stmt
 
-train_stmt: "TRAIN" "MODEL" NAME "USING" algorithm "FROM" NAME "PREDICT" NAME features
+train_stmt: "TRAIN" "MODEL" NAME "USING" algorithm "FROM" NAME "PREDICT" NAME features option*
 
 algorithm: NAME ("(" param_list? ")")?
 param_list: param ("," param)*
@@ -19,12 +19,47 @@ value: NUMBER | ESCAPED_STRING | NAME
 features: "WITH" "FEATURES" "(" feature_list? ")"
 feature_list: NAME ("," NAME)*
 
+option: validate_stmt
+      | optimize_stmt
+      | stop_stmt
+      | split_stmt
+
+validate_stmt: "VALIDATE" ("USING" NAME ("(" param_list? ")")? | "ON" NAME)
+optimize_stmt: "OPTIMIZE" "FOR" NAME
+stop_stmt: "STOP" "WHEN" condition_expr
+split_stmt: "SPLIT" "DATA" split_entries
+
+split_entries: split_entry ("," split_entry)*
+split_entry: NAME "=" NUMBER
+
+?condition_expr: or_expr
+?or_expr: and_expr ("OR" and_expr)*
+?and_expr: comparison ("AND" comparison)*
+comparison: NAME COMP_OP value
+COMP_OP: ">=" | "<=" | ">" | "<" | "!=" | "="
+
 %import common.CNAME -> NAME
 %import common.NUMBER
 %import common.ESCAPED_STRING
 %import common.WS
 %ignore WS
 """
+
+@dataclass
+class DataSplit:
+    ratios: Dict[str, float]
+
+
+@dataclass
+class ValidationOption:
+    method: Optional[str] = None
+    params: Optional[List[tuple[str, Any]]] = None
+    on: Optional[str] = None
+
+
+@dataclass
+class OptimizeOption:
+    metric: str
 
 @dataclass
 class TrainModel:
@@ -34,6 +69,10 @@ class TrainModel:
     source: str
     target: str
     features: List[str]
+    split: Optional[DataSplit] = None
+    validate: Optional[ValidationOption] = None
+    optimize_metric: Optional[str] = None
+    stop_condition: Optional[str] = None
 
 
 class TreeToModel(Transformer):
@@ -71,10 +110,53 @@ class TreeToModel(Transformer):
     def features(self, items):
         return items[0] if items else []
 
+    def option(self, items):
+        return items[0]
+
+    def split_entry(self, items):
+        name, value = items
+        return name, value
+
+    def split_entries(self, items):
+        return dict(items)
+
+    def split_stmt(self, items):
+        return DataSplit(items[0])
+
+    def validate_stmt(self, items):
+        if len(items) == 1:
+            return ValidationOption(on=items[0])
+        else:
+            method = items[0]
+            params = items[1] if len(items) > 1 else None
+            return ValidationOption(method=method, params=params)
+
+    def optimize_stmt(self, items):
+        return OptimizeOption(metric=items[0])
+
+    def comparison(self, items):
+        left, op, right = items
+        return f"{left} {op} {right}"
+
+    def and_expr(self, items):
+        expr = items[0]
+        for part in items[1:]:
+            expr += f" AND {part}"
+        return expr
+
+    def or_expr(self, items):
+        expr = items[0]
+        for part in items[1:]:
+            expr += f" OR {part}"
+        return expr
+
+    def stop_stmt(self, items):
+        return items[0]
+
     @v_args(inline=True)
-    def train_stmt(self, model_name, algorithm, source, target, features):
+    def train_stmt(self, model_name, algorithm, source, target, features, *options):
         alg_name, params = algorithm
-        return TrainModel(
+        model = TrainModel(
             name=model_name,
             algorithm=alg_name,
             params=params,
@@ -82,6 +164,16 @@ class TreeToModel(Transformer):
             target=target,
             features=features,
         )
+        for opt in options:
+            if isinstance(opt, DataSplit):
+                model.split = opt
+            elif isinstance(opt, ValidationOption):
+                model.validate = opt
+            elif isinstance(opt, OptimizeOption):
+                model.optimize_metric = opt.metric
+            elif isinstance(opt, str):
+                model.stop_condition = opt
+        return model
 
 
 def parse(text: str) -> TrainModel:
@@ -99,14 +191,29 @@ def compile_sql(model: TrainModel) -> str:
     params_json = json.dumps(params_dict)
     training_query = f"SELECT {feature_cols}, {model.target} FROM {model.source}"
     feature_array = ", ".join(repr(f) for f in model.features)
-    sql = (
-        "SELECT ml_train_model("
-        f"model_name := {repr(model.name)}, "
-        f"algorithm := {repr(model.algorithm)}, "
-        f"algorithm_params := {repr(params_json)}, "
-        f"training_data := {repr(training_query)}, "
-        f"target_column := {repr(model.target)}, "
-        f"feature_columns := ARRAY[{feature_array}]"
-        ")"
-    )
+    args = [
+        f"model_name := {repr(model.name)}",
+        f"algorithm := {repr(model.algorithm)}",
+        f"algorithm_params := {repr(params_json)}",
+        f"training_data := {repr(training_query)}",
+        f"target_column := {repr(model.target)}",
+        f"feature_columns := ARRAY[{feature_array}]",
+    ]
+    if model.split:
+        args.append(f"data_split := {repr(json.dumps(model.split.ratios))}")
+    if model.validate:
+        if model.validate.on:
+            args.append(f"validate_on := {repr(model.validate.on)}")
+        if model.validate.method:
+            args.append(f"validate_method := {repr(model.validate.method)}")
+            if model.validate.params:
+                args.append(
+                    f"validate_params := {repr(json.dumps(dict(model.validate.params)))}"
+                )
+    if model.optimize_metric:
+        args.append(f"optimize_metric := {repr(model.optimize_metric)}")
+    if model.stop_condition:
+        args.append(f"stop_condition := {repr(model.stop_condition)}")
+
+    sql = "SELECT ml_train_model(" + ", ".join(args) + ")"
     return sql

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -34,5 +34,20 @@ class TestParser(unittest.TestCase):
         self.assertEqual(model.target, "outcome")
         self.assertEqual(model.features, ["a", "b"])
 
+    def test_parse_train_model_with_options(self):
+        text = (
+            "TRAIN MODEL m USING alg() FROM data PREDICT y WITH FEATURES(f1, f2) "
+            "SPLIT DATA training=0.7, validation=0.2, test=0.1 "
+            "VALIDATE USING cv(folds=5) OPTIMIZE FOR accuracy "
+            "STOP WHEN accuracy > 0.9"
+        )
+        model = parser.parse(text)
+        self.assertIsNotNone(model.split)
+        self.assertAlmostEqual(model.split.ratios["training"], 0.7)
+        self.assertIsNotNone(model.validate)
+        self.assertEqual(model.validate.method, "cv")
+        self.assertEqual(model.optimize_metric, "accuracy")
+        self.assertEqual(model.stop_condition, "accuracy > 0.9")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add grammar for validation, optimization, early stopping and data splits
- support new fields in `TrainModel` dataclass
- generate SQL with the additional options
- test parsing of the new grammar elements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685334205b788328b37bed6841a59c07