### PR TITLE
Add linting workflow and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,18 @@ jobs:
           python-version: '3.x'
       - name: Verify documentation files
         run: python scripts/check_docs.py
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install black flake8
+      - name: Run black
+        run: black --check dsl tests
+      - name: Run flake8
+        run: flake8 dsl tests

--- a/dsl/__init__.py
+++ b/dsl/__init__.py
@@ -1,4 +1,3 @@
-
 """DSL parsing and compilation utilities."""
 
 from .parser import TrainModel, compile_sql, parse

--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -9,7 +9,7 @@ from lark import Lark, Transformer, v_args
 dsl_grammar = r"""
 ?start: train_stmt
 
-train_stmt: "TRAIN" "MODEL" NAME "USING" algorithm "FROM" NAME "PREDICT" NAME features
+train_stmt: "TRAIN" "MODEL" NAME "USING" algorithm "FROM" NAME "PREDICT" NAME features  # noqa: E501
 
 algorithm: NAME ("(" param_list? ")")?
 param_list: param ("," param)*
@@ -25,6 +25,7 @@ feature_list: NAME ("," NAME)*
 %import common.WS
 %ignore WS
 """
+
 
 @dataclass
 class TrainModel:
@@ -45,7 +46,7 @@ class TreeToModel(Transformer):
         return float(text) if "." in text else int(text)
 
     def ESCAPED_STRING(self, token):
-        return token.value.strip("\"")
+        return token.value.strip('"')
 
     def value(self, items):
         return items[0]
@@ -97,7 +98,9 @@ def compile_sql(model: TrainModel) -> str:
     feature_cols = ", ".join(model.features)
     params_dict = {k: v for k, v in model.params}
     params_json = json.dumps(params_dict)
-    training_query = f"SELECT {feature_cols}, {model.target} FROM {model.source}"
+    training_query = (
+        f"SELECT {feature_cols}, {model.target} FROM {model.source}"
+    )
     feature_array = ", ".join(repr(f) for f in model.features)
     sql = (
         "SELECT ml_train_model("

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,30 +2,31 @@ import os
 import re
 
 DOC_FILES = [
-    'README.md',
-    'AGENTS.md',
-    'DSL.md',
-    'EXTENSIONS.md',
-    'DISTRIBUTED.md',
+    "README.md",
+    "AGENTS.md",
+    "DSL.md",
+    "EXTENSIONS.md",
+    "DISTRIBUTED.md",
 ]
 
 # Ensure all documentation files exist
 for f in DOC_FILES:
     assert os.path.exists(f), f"Documentation file missing: {f}"
 
+
 def test_markdown_headings():
-    pattern = re.compile(r'^# .+', re.MULTILINE)
+    pattern = re.compile(r"^# .+", re.MULTILINE)
     for f in DOC_FILES:
-        with open(f, 'r', encoding='utf-8') as fh:
+        with open(f, "r", encoding="utf-8") as fh:
             content = fh.read()
         assert pattern.search(content), f"{f} missing top-level heading"
 
 
 def test_readme_links():
-    with open('README.md', 'r', encoding='utf-8') as fh:
+    with open("README.md", "r", encoding="utf-8") as fh:
         readme = fh.read()
     # Check that README links to each doc file
     for f in DOC_FILES:
-        if f == 'README.md':
+        if f == "README.md":
             continue
         assert f"`{f}`" in readme, f"README.md missing reference to {f}"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,15 +1,17 @@
-import unittest
 import os
 import sys
+import unittest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from dsl import parser
+from dsl import parser  # noqa: E402
+
 
 class TestParser(unittest.TestCase):
     def test_parse_train_model(self):
         text = (
-            "TRAIN MODEL fraud_detector USING logistic_regression(regularization=0.01) FROM transactions "
+            "TRAIN MODEL fraud_detector USING logistic_regression("
+            "regularization=0.01) FROM transactions "
             "PREDICT is_fraud WITH FEATURES(amount, merchant_type)"
         )
         model = parser.parse(text)
@@ -33,6 +35,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(model.source, "training_data")
         self.assertEqual(model.target, "outcome")
         self.assertEqual(model.features, ["a", "b"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- run black and flake8 in CI
- format dsl and tests with black
- fix flake8 issues in parser and tests

## Testing
- `flake8 dsl tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685334201db88328ad063797707a775c