### PR TITLE
Add pre-commit linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install dependencies
-        run: pip install black flake8
-      - name: Run black
-        run: black --check dsl tests
-      - name: Run flake8
-        run: flake8 dsl tests
+        run: pip install -r requirements.txt
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.pre-commit/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ DeclarativeML brings machine learning directly into the database layer using a n
 ## Core Principles
 
 1. **Database-Native Everything**: All ML operations, coordination, and state management happen within the database layer
-2. **Declarative DSL**: Express ML workflows in natural language that compiles to optimized database operations  
+2. **Declarative DSL**: Express ML workflows in natural language that compiles to optimized database operations
 3. **Performance Boundaries**: Only performance-critical kernels (matrix multiplication, CUDA operations) execute outside the database
 4. **Event-Driven Coordination**: Pub/sub messaging with worker pools eliminates synchronization bottlenecks
 5. **Autonomous Operation**: Database agents handle optimization, monitoring, and lifecycle management
@@ -32,7 +32,7 @@ DeclarativeML brings machine learning directly into the database layer using a n
 -- Train a model with natural language syntax
 TRAIN MODEL fraud_detector
   USING neural_network(layers=[128, 64, 32])
-  FROM transactions  
+  FROM transactions
   PREDICT is_fraudulent
   WITH FEATURES (amount, merchant_category, time_of_day, user_history)
   BALANCE CLASSES BY oversampling
@@ -40,7 +40,7 @@ TRAIN MODEL fraud_detector
   OPTIMIZE FOR recall
   STOP WHEN recall > 0.90 OR epochs > 100;
 
--- Deploy and monitor automatically  
+-- Deploy and monitor automatically
 WHEN MODEL fraud_detector CONVERGED
   DEPLOY TO real_time_scoring
   NOTIFY ops_team
@@ -59,7 +59,7 @@ CREATE AGENT overfitting_monitor
 
 **Current Focus:**
 - Database schema design for ML primitives
-- DSL parser and SQL compilation 
+- DSL parser and SQL compilation
 - PostgreSQL extension framework
 - Pub/sub messaging system implementation
 
@@ -108,6 +108,21 @@ When code becomes available:
 
 Install the Python dependencies with `pip install -r requirements.txt` and then
 run `pytest` from the repository root to verify the test suite passes.
+
+### Linting and Formatting
+
+This project uses [pre-commit](https://pre-commit.com/) to run Black, isort and
+Flake8. After installing the dependencies, install the git hook:
+
+```bash
+pre-commit install
+```
+
+Run all checks manually with:
+
+```bash
+pre-commit run --all-files
+```
 
 ### CLI Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 pytest
 lark
 hypothesis
+pre-commit
+black
+flake8
+isort


### PR DESCRIPTION
## Summary
- add pre-commit configuration for black, isort and flake8
- update CI to run pre-commit
- document pre-commit usage
- include lint tools in requirements
- ignore pre-commit cache files

## Testing
- `pre-commit run --files README.md requirements.txt .pre-commit-config.yaml .github/workflows/ci.yml .gitignore`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685336054b30832888e859db1988691d