### PR TITLE
Add pytest job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,16 @@ jobs:
         run: pip install -r requirements.txt
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest -q


### PR DESCRIPTION
## Summary
- extend CI to run tests

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685338aa8bdc83288ac7d64bc82aacdd