### PR TITLE
Enable signed numbers in DSL grammar

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -14,7 +14,7 @@ train_stmt: "TRAIN" "MODEL" NAME "USING" algorithm "FROM" NAME "PREDICT" NAME fe
 algorithm: NAME ("(" param_list? ")")?
 param_list: param ("," param)*
 param: NAME "=" value
-value: NUMBER | ESCAPED_STRING | NAME
+value: SIGNED_NUMBER | ESCAPED_STRING | NAME
 
 features: "WITH" "FEATURES" "(" feature_list? ")"
 feature_list: NAME ("," NAME)*
@@ -30,7 +30,7 @@ stop_stmt: "STOP" "WHEN" condition_expr
 split_stmt: "SPLIT" "DATA" split_entries
 
 split_entries: split_entry ("," split_entry)*
-split_entry: NAME "=" NUMBER
+split_entry: NAME "=" SIGNED_NUMBER
 
 ?condition_expr: or_expr
 ?or_expr: and_expr ("OR" and_expr)*
@@ -39,7 +39,7 @@ comparison: NAME COMP_OP value
 COMP_OP: ">=" | "<=" | ">" | "<" | "!=" | "="
 
 %import common.CNAME -> NAME
-%import common.NUMBER
+%import common.SIGNED_NUMBER
 %import common.ESCAPED_STRING
 %import common.WS
 %ignore WS
@@ -80,7 +80,7 @@ class TreeToModel(Transformer):
     def NAME(self, token):
         return str(token)
 
-    def NUMBER(self, token):
+    def SIGNED_NUMBER(self, token):
         text = token.value
         return float(text) if "." in text else int(text)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -73,6 +73,14 @@ class TestParser(unittest.TestCase):
         model = parser.parse(text)
         self.assertEqual(model.params, [("num", 1), ("rate", 0.5), ("name", "x")])
 
+    def test_negative_param_values(self):
+        text = (
+            "TRAIN MODEL m USING alg(alpha=-0.1, depth=-5) FROM t "
+            "PREDICT y WITH FEATURES(a)"
+        )
+        model = parser.parse(text)
+        self.assertEqual(model.params, [("alpha", -0.1), ("depth", -5)])
+
 
 @given(
     model_name=st.text(min_size=1, alphabet=st.characters(min_codepoint=97, max_codepoint=122)),


### PR DESCRIPTION
## Summary
- allow optional `+`/`-` prefixes for numbers in grammar
- parse signed numbers in the transformer
- test negative numeric parameter values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685338ae074483288af7d41d3e3f1987