### PR TITLE
Add CLI file input test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 
 
@@ -19,6 +20,28 @@ class TestCLI(unittest.TestCase):
             cwd=repo_root,
             check=True,
         )
+        output = result.stdout.decode()
+        self.assertIn("ml_train_model", output)
+
+    def test_cli_file(self):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        dsl_text = (
+            "TRAIN MODEL file_model USING decision_tree FROM data "
+            "PREDICT label WITH FEATURES(x, y)"
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".dsl", delete=False) as tmp:
+            tmp.write(dsl_text)
+            tmp_path = tmp.name
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "dsl.cli", tmp_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=repo_root,
+                check=True,
+            )
+        finally:
+            os.remove(tmp_path)
         output = result.stdout.decode()
         self.assertIn("ml_train_model", output)
 


### PR DESCRIPTION
## Summary
- add `tempfile` import for new test
- implement `test_cli_file` ensuring CLI works with file input

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685969d0e0b0832885ce4eec663c43eb