### PR TITLE
Add BALANCE clause support in parser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -83,6 +83,14 @@ class TestParser(unittest.TestCase):
         model = parser.parse(text)
         self.assertEqual(model.params, [("alpha", -0.1), ("depth", -5)])
 
+    def test_balance_clause(self):
+        text = (
+            "TRAIN MODEL m USING alg() FROM t PREDICT y WITH FEATURES(a) "
+            "BALANCE CLASSES BY oversampling"
+        )
+        model = parser.parse(text)
+        self.assertEqual(model.balance_method, "oversampling")
+
 
 @given(
     model_name=st.text(


### PR DESCRIPTION
## Summary
- support `BALANCE CLASSES BY` in DSL parser
- expose parsed balance method in `TrainModel`
- include balance method when compiling SQL
- test parsing of the BALANCE clause

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685969d00e7c83289c29b453bdfd3dfe