### PR TITLE
Add Triton COMPUTE kernel parsing

### DIFF
--- a/DSL.md
+++ b/DSL.md
@@ -91,8 +91,21 @@ WITH FEATURES (
   signup_channel,
   TRANSFORM standard_scaler(income),
   TRANSFORM one_hot_encoder(product_category),
-  TRANSFORM time_series.lag(revenue, periods=[1,7,30])
+TRANSFORM time_series.lag(revenue, periods=[1,7,30])
 );
+```
+
+### GPU Compute Kernels
+
+```sql
+COMPUTE add_vectors
+  FROM table(foo, bar)
+  INTO column(baz)
+  USING vector_add BLOCK 256 GRID auto;
+
+COMPUTE scan_peptides
+  EVERY 1000 TICKS
+  USING immune_scan SHARED 1K;
 ```
 
 ### Event-Driven Workflows

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ CREATE AGENT overfitting_monitor
   CHECK MODEL fraud_detector EVERY 10 epochs
   WHEN validation_loss INCREASES FOR 3 consecutive_checks
   THEN stop_training AND rollback_to_best_checkpoint;
+
+-- GPU compute kernels
+COMPUTE add_vectors
+  FROM table(foo, bar)
+  INTO column(baz)
+  USING vector_add BLOCK 256 GRID auto;
 ```
 
 ## Status

--- a/dsl/__init__.py
+++ b/dsl/__init__.py
@@ -1,6 +1,6 @@
 """DSL parsing and compilation utilities."""
 
 from . import cli
-from .parser import TrainModel, compile_sql, parse
+from .parser import ComputeKernel, TrainModel, compile_sql, parse
 
-__all__ = ["TrainModel", "parse", "compile_sql", "cli"]
+__all__ = ["TrainModel", "ComputeKernel", "parse", "compile_sql", "cli"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,23 @@ class TestCLI(unittest.TestCase):
         output = result.stdout.decode()
         self.assertIn("ml_train_model", output)
 
+    def test_cli_compute(self):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        dsl_text = (
+            "COMPUTE add_vectors FROM table(a, b) INTO column(c) "
+            "USING vector_add BLOCK 128"
+        )
+        result = subprocess.run(
+            [sys.executable, "-m", "dsl.cli"],
+            input=dsl_text.encode(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=repo_root,
+            check=True,
+        )
+        output = result.stdout.decode()
+        self.assertIn("ml_register_compute", output)
+
     def test_cli_file(self):
         repo_root = os.path.dirname(os.path.dirname(__file__))
         dsl_text = (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -91,6 +91,27 @@ class TestParser(unittest.TestCase):
         model = parser.parse(text)
         self.assertEqual(model.balance_method, "oversampling")
 
+    def test_parse_compute(self):
+        text = (
+            "COMPUTE add_vectors FROM table(foo, bar) INTO column(baz) "
+            "USING vector_add BLOCK 256 GRID auto"
+        )
+        stmt = parser.parse(text)
+        self.assertIsInstance(stmt, parser.ComputeKernel)
+        self.assertEqual(stmt.name, "add_vectors")
+        self.assertEqual(stmt.inputs, ["foo", "bar"])
+        self.assertEqual(stmt.output, "baz")
+        self.assertEqual(stmt.kernel, "vector_add")
+        self.assertEqual(stmt.options["BLOCK"], 256)
+        self.assertEqual(stmt.options["GRID"], "auto")
+
+    def test_parse_compute_every(self):
+        text = "COMPUTE scan_peptides EVERY 1000 TICKS USING immune_scan SHARED 1K"
+        stmt = parser.parse(text)
+        self.assertEqual(stmt.schedule_ticks, 1000)
+        self.assertEqual(stmt.kernel, "immune_scan")
+        self.assertEqual(stmt.options["SHARED"], "1K")
+
 
 @given(
     model_name=st.text(


### PR DESCRIPTION
## Summary
- support COMPUTE statements in the DSL parser
- expose new ComputeKernel class from `dsl`
- compile COMPUTE to `ml_register_compute` SQL
- document GPU compute kernels in README and DSL spec
- test parsing and CLI behavior for COMPUTE

## Testing
- `pip install -q pytest lark hypothesis pre-commit black flake8 isort`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a62639d90832892c28736bdb1b5a4