### PR TITLE
Handle CLI parse errors

### DIFF
--- a/dsl/cli.py
+++ b/dsl/cli.py
@@ -1,6 +1,8 @@
 import argparse
 import sys
 
+from lark.exceptions import LarkError
+
 from .parser import compile_sql, parse
 
 
@@ -22,8 +24,13 @@ def main(argv: list[str] | None = None) -> int:
     else:
         text = sys.stdin.read()
 
-    model = parse(text)
-    sql = compile_sql(model)
+    try:
+        model = parse(text)
+        sql = compile_sql(model)
+    except LarkError as exc:
+        print(f"Failed to parse DSL: {exc}", file=sys.stderr)
+        return 1
+
     # Print the generated SQL with a trailing newline to ensure a clean output
     # when redirecting to files or piping to other commands.
     sys.stdout.write(sql + "\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,18 @@ class TestCLI(unittest.TestCase):
         output = result.stdout.decode()
         self.assertIn("ml_train_model", output)
 
+    def test_cli_invalid_input(self):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        bad_dsl = "TRAIN MODEL"
+        result = subprocess.run(
+            [sys.executable, "-m", "dsl.cli"],
+            input=bad_dsl.encode(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=repo_root,
+        )
+        self.assertNotEqual(result.returncode, 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- catch `LarkError` when running the CLI
- print error messages to stderr and return a non-zero code
- test that invalid DSL input causes CLI failure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bfeb790fc832892d19a42ff4a3953