### PR TITLE
Add code style config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,14 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://example.com"
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+line_length = 88
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,9 +1,10 @@
 import unittest
 
+from hypothesis import given
+from hypothesis import strategies as st
+from lark.exceptions import LarkError
 
 from dsl import parser
-from lark.exceptions import LarkError
-from hypothesis import given, strategies as st
 
 
 class TestParser(unittest.TestCase):


### PR DESCRIPTION
## Summary
- configure flake8 max line length and ignore E203
- match Black and isort settings
- run isort on tests

## Testing
- `pre-commit run --files dsl/parser.py tests/test_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_688bfeb6ac688328aedd2e1c4f6b6bb1