### PR TITLE
Fix long lines in parser

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -311,7 +311,7 @@ def compile_sql(model: Any) -> str:
         params_dict = {k: v for k, v in model.params}
         params_json = json.dumps(params_dict)
         training_query = (
-            "SELECT " + f"{feature_cols}, {model.target} " + f"FROM {model.source}"
+            f"SELECT {feature_cols}, {model.target} " f"FROM {model.source}"
         )
         feature_array = ", ".join(repr(f) for f in model.features)
         args = [
@@ -323,12 +323,14 @@ def compile_sql(model: Any) -> str:
             f"feature_columns := ARRAY[{feature_array}]",
         ]
         if model.split:
-            args.append(f"data_split := {repr(json.dumps(model.split.ratios))}")
+            data_split = repr(json.dumps(model.split.ratios))
+            args.append(f"data_split := {data_split}")
         if model.validate:
             if model.validate.on:
                 args.append(f"validate_on := {repr(model.validate.on)}")
             if model.validate.method:
-                args.append(f"validate_method := {repr(model.validate.method)}")
+                val_method = repr(model.validate.method)
+                args.append(f"validate_method := {val_method}")
                 if model.validate.params:
                     params_json = json.dumps(dict(model.validate.params))
                     args.append(f"validate_params := {repr(params_json)}")
@@ -343,7 +345,10 @@ def compile_sql(model: Any) -> str:
         return sql
 
     if isinstance(model, ComputeKernel):
-        args = [f"kernel_name := {repr(model.kernel)}", f"name := {repr(model.name)}"]
+        args = [
+            f"kernel_name := {repr(model.kernel)}",
+            f"name := {repr(model.name)}",
+        ]
         if model.inputs:
             inputs_array = ", ".join(repr(i) for i in model.inputs)
             args.append(f"inputs := ARRAY[{inputs_array}]")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,9 +1,10 @@
 import unittest
 
+from hypothesis import given
+from hypothesis import strategies as st
+from lark.exceptions import LarkError
 
 from dsl import parser
-from lark.exceptions import LarkError
-from hypothesis import given, strategies as st
 
 
 class TestParser(unittest.TestCase):
@@ -106,7 +107,12 @@ class TestParser(unittest.TestCase):
         self.assertEqual(stmt.options["GRID"], "auto")
 
     def test_parse_compute_every(self):
-        text = "COMPUTE scan_peptides EVERY 1000 TICKS USING immune_scan SHARED 1K"
+        text = " ".join(
+            [
+                "COMPUTE scan_peptides EVERY 1000 TICKS USING immune_scan",
+                "SHARED 1K",
+            ]
+        )
         stmt = parser.parse(text)
         self.assertEqual(stmt.schedule_ticks, 1000)
         self.assertEqual(stmt.kernel, "immune_scan")


### PR DESCRIPTION
## Summary
- wrap long string operations in `dsl/parser.py`
- shorten compute example in `tests/test_parser.py`

## Testing
- `pre-commit run --files dsl/parser.py tests/test_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_688bfeb9e96c8328bcbdc18f796dee35