### PR TITLE
Raise error for unexpected compute parts

### DIFF
--- a/DSL.md
+++ b/DSL.md
@@ -108,6 +108,16 @@ COMPUTE scan_peptides
   USING immune_scan SHARED 1K;
 ```
 
+Supported compute clauses include:
+
+- `FROM table(col1, col2, ...)` to specify input columns
+- `INTO column(name)` to designate an output column
+- `EVERY <ticks> TICKS` to schedule periodic execution
+- `USING <kernel>` to select the GPU kernel
+- `BLOCK <number>` to set thread block size
+- `GRID <name>` to choose a grid strategy
+- `SHARED <size>` to allocate shared memory (e.g., `1K`)
+
 ### Event-Driven Workflows
 
 ```sql

--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -285,8 +285,7 @@ class TreeToModel(Transformer):
                 key, val = part
                 options[key] = val
             else:
-                # ignore unexpected parts
-                pass
+                raise ValueError(f"Unexpected compute clause part: {part!r}")
         if kernel_name is None:
             raise ValueError("Kernel name missing")
         return ComputeKernel(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -113,6 +113,17 @@ class TestParser(unittest.TestCase):
         self.assertEqual(stmt.kernel, "immune_scan")
         self.assertEqual(stmt.options["SHARED"], "1K")
 
+    def test_parse_compute_invalid_clause(self):
+        text = "COMPUTE bad_job USING some_kernel EXTRA"
+        with self.assertRaises(LarkError):
+            parser.parse(text)
+
+    def test_compute_stmt_unexpected_part(self):
+        transformer = parser.TreeToModel()
+        with self.assertRaises(ValueError) as ctx:
+            transformer.compute_stmt("bad_job", "kernel", 123)
+        self.assertIn("Unexpected compute clause part", str(ctx.exception))
+
 
 @given(
     model_name=st.text(


### PR DESCRIPTION
## Summary
- raise `ValueError` for unexpected compute clause parts
- test invalid compute clauses for clear error messages
- document all supported compute options

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_689550380e408328a89202528433c146