### PR TITLE
Handle missing file in CLI

### DIFF
--- a/dsl/cli.py
+++ b/dsl/cli.py
@@ -19,8 +19,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.source:
-        with open(args.source, "r", encoding="utf-8") as fh:
-            text = fh.read()
+        try:
+            with open(args.source, "r", encoding="utf-8") as fh:
+                text = fh.read()
+        except OSError as exc:
+            print(
+                f"Failed to read source file '{args.source}': {exc}",
+                file=sys.stderr,
+            )
+            return 1
     else:
         text = sys.stdin.read()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,18 @@ class TestCLI(unittest.TestCase):
         )
         self.assertNotEqual(result.returncode, 0)
 
+    def test_cli_missing_file(self):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        missing_path = os.path.join(repo_root, "does_not_exist.dsl")
+        result = subprocess.run(
+            [sys.executable, "-m", "dsl.cli", missing_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=repo_root,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Failed to read source file", result.stderr.decode())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Gracefully handle missing DSL source files by catching `OSError` in the CLI.
- Add regression test for running CLI with a non-existent file.

## Testing
- `pre-commit run --files dsl/cli.py tests/test_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895503d63c08328a3f1ad7c0f212ab4