### PR TITLE
Require kernel name for compute operations

### DIFF
--- a/DSL.md
+++ b/DSL.md
@@ -108,6 +108,9 @@ COMPUTE scan_peptides
   USING immune_scan SHARED 1K;
 ```
 
+The `USING` clause must always specify the kernel name; it is a required
+parameter for registering a compute kernel.
+
 ### Event-Driven Workflows
 
 ```sql

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ COMPUTE add_vectors
   USING vector_add BLOCK 256 GRID auto;
 ```
 
+A kernel name is mandatory in the `USING` clause for all `COMPUTE` statements.
+
 ## Status
 
 🚧 **Early Development** - Building core architecture and DSL compiler

--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -110,10 +110,10 @@ class TrainModel:
 @dataclass
 class ComputeKernel:
     name: str
+    kernel: str
     inputs: Optional[List[str]] = None
     output: Optional[str] = None
     schedule_ticks: Optional[int] = None
-    kernel: str = ""
     options: Dict[str, Any] | None = None
 
 
@@ -263,13 +263,13 @@ class TreeToModel(Transformer):
     @v_args(inline=True)
     def compute_stmt(
         self,
-        name,
-        *parts,
-    ):
-        inputs = None
-        output = None
-        schedule = None
-        kernel_name = None
+        name: str,
+        *parts: Any,
+    ) -> ComputeKernel:
+        inputs: Optional[List[str]] = None
+        output: Optional[str] = None
+        schedule: Optional[int] = None
+        kernel_name: Optional[str] = None
         options: Dict[str, Any] = {}
 
         for part in parts:
@@ -299,13 +299,13 @@ class TreeToModel(Transformer):
         )
 
 
-def parse(text: str) -> Any:
+def parse(text: str) -> TrainModel | ComputeKernel:
     tree = _PARSER.parse(text)
     model = TreeToModel().transform(tree)
     return model
 
 
-def compile_sql(model: Any) -> str:
+def compile_sql(model: TrainModel | ComputeKernel) -> str:
     import json
 
     if isinstance(model, TrainModel):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -113,6 +113,11 @@ class TestParser(unittest.TestCase):
         self.assertEqual(stmt.kernel, "immune_scan")
         self.assertEqual(stmt.options["SHARED"], "1K")
 
+    def test_compute_missing_kernel(self):
+        text = "COMPUTE add_vectors FROM table(foo) INTO column(bar)"
+        with self.assertRaises(LarkError):
+            parser.parse(text)
+
 
 @given(
     model_name=st.text(


### PR DESCRIPTION
## Summary
- make `kernel` a required field on `ComputeKernel`
- improve type hints and enforce kernel presence during parse
- document mandatory kernel names in compute DSL
- add regression test for missing kernel

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895503a1abc8328a98ef22f13ea8ad7