### PR TITLE
Validate DataSplit ratios sum to one

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -113,6 +113,23 @@ class TestParser(unittest.TestCase):
         self.assertEqual(stmt.kernel, "immune_scan")
         self.assertEqual(stmt.options["SHARED"], "1K")
 
+    def test_data_split_sum_validation_passes(self):
+        text = (
+            "TRAIN MODEL m USING alg() FROM t PREDICT y WITH FEATURES(a, b) "
+            "SPLIT DATA train=0.8, test=0.2"
+        )
+        model = parser.parse(text)
+        self.assertIsNotNone(model.split)
+        self.assertAlmostEqual(sum(model.split.ratios.values()), 1.0)
+
+    def test_data_split_sum_validation_fails(self):
+        text = (
+            "TRAIN MODEL m USING alg() FROM t PREDICT y WITH FEATURES(a, b) "
+            "SPLIT DATA train=0.6, test=0.3"
+        )
+        with self.assertRaises(ValueError):
+            parser.parse(text)
+
 
 @given(
     model_name=st.text(


### PR DESCRIPTION
## Summary
- ensure `DataSplit` ratios sum to 1.0 and raise `ValueError` otherwise
- add parser tests covering valid and invalid ratio sums

## Testing
- `pre-commit run --files dsl/parser.py tests/test_parser.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895503b7e0883289cb7dc57924a8988