### PR TITLE
Use psycopg builder for safe SQL compilation

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from lark import Lark, Transformer, v_args
+from psycopg import sql
 
 dsl_grammar = r"""
 ?start: train_stmt
@@ -309,53 +310,109 @@ def compile_sql(model: Any) -> str:
     import json
 
     if isinstance(model, TrainModel):
-        feature_cols = ", ".join(model.features)
-        params_dict = {k: v for k, v in model.params}
-        params_json = json.dumps(params_dict)
+        # build training query with properly quoted identifiers
+        field_idents = [sql.Identifier(f) for f in model.features]
+        field_idents.append(sql.Identifier(model.target))
         training_query = (
-            "SELECT " + f"{feature_cols}, {model.target} " + f"FROM {model.source}"
+            sql.SQL("SELECT {fields} FROM {source}")
+            .format(
+                fields=sql.SQL(", ").join(field_idents),
+                source=sql.Identifier(model.source),
+            )
+            .as_string(None)
         )
-        feature_array = ", ".join(repr(f) for f in model.features)
+
         args = [
-            f"model_name := {repr(model.name)}",
-            f"algorithm := {repr(model.algorithm)}",
-            f"algorithm_params := {repr(params_json)}",
-            f"training_data := {repr(training_query)}",
-            f"target_column := {repr(model.target)}",
-            f"feature_columns := ARRAY[{feature_array}]",
+            sql.SQL("model_name := {val}").format(val=sql.Literal(model.name)),
+            sql.SQL("algorithm := {val}").format(val=sql.Literal(model.algorithm)),
+            sql.SQL("algorithm_params := {val}").format(
+                val=sql.Literal(json.dumps(dict(model.params)))
+            ),
+            sql.SQL("training_data := {val}").format(val=sql.Literal(training_query)),
+            sql.SQL("target_column := {val}").format(val=sql.Literal(model.target)),
+            sql.SQL("feature_columns := ARRAY[{vals}]").format(
+                vals=sql.SQL(", ").join(sql.Literal(f) for f in model.features)
+            ),
         ]
         if model.split:
-            args.append(f"data_split := {repr(json.dumps(model.split.ratios))}")
+            args.append(
+                sql.SQL("data_split := {val}").format(
+                    val=sql.Literal(json.dumps(model.split.ratios))
+                )
+            )
         if model.validate:
             if model.validate.on:
-                args.append(f"validate_on := {repr(model.validate.on)}")
+                args.append(
+                    sql.SQL("validate_on := {val}").format(
+                        val=sql.Literal(model.validate.on)
+                    )
+                )
             if model.validate.method:
-                args.append(f"validate_method := {repr(model.validate.method)}")
+                args.append(
+                    sql.SQL("validate_method := {val}").format(
+                        val=sql.Literal(model.validate.method)
+                    )
+                )
                 if model.validate.params:
-                    params_json = json.dumps(dict(model.validate.params))
-                    args.append(f"validate_params := {repr(params_json)}")
+                    args.append(
+                        sql.SQL("validate_params := {val}").format(
+                            val=sql.Literal(json.dumps(dict(model.validate.params)))
+                        )
+                    )
         if model.optimize_metric:
-            args.append(f"optimize_metric := {repr(model.optimize_metric)}")
+            args.append(
+                sql.SQL("optimize_metric := {val}").format(
+                    val=sql.Literal(model.optimize_metric)
+                )
+            )
         if model.stop_condition:
-            args.append(f"stop_condition := {repr(model.stop_condition)}")
+            args.append(
+                sql.SQL("stop_condition := {val}").format(
+                    val=sql.Literal(model.stop_condition)
+                )
+            )
         if model.balance_method:
-            args.append(f"balance_method := {repr(model.balance_method)}")
+            args.append(
+                sql.SQL("balance_method := {val}").format(
+                    val=sql.Literal(model.balance_method)
+                )
+            )
 
-        sql = "SELECT ml_train_model(" + ", ".join(args) + ")"
-        return sql
+        query = sql.SQL("SELECT ml_train_model({args})").format(
+            args=sql.SQL(", ").join(args)
+        )
+        return query.as_string(None)
 
     if isinstance(model, ComputeKernel):
-        args = [f"kernel_name := {repr(model.kernel)}", f"name := {repr(model.name)}"]
+        args = [
+            sql.SQL("kernel_name := {val}").format(val=sql.Literal(model.kernel)),
+            sql.SQL("name := {val}").format(val=sql.Literal(model.name)),
+        ]
         if model.inputs:
-            inputs_array = ", ".join(repr(i) for i in model.inputs)
-            args.append(f"inputs := ARRAY[{inputs_array}]")
+            args.append(
+                sql.SQL("inputs := ARRAY[{vals}]").format(
+                    vals=sql.SQL(", ").join(sql.Literal(i) for i in model.inputs)
+                )
+            )
         if model.output:
-            args.append(f"output := {repr(model.output)}")
+            args.append(
+                sql.SQL("output := {val}").format(val=sql.Literal(model.output))
+            )
         if model.schedule_ticks is not None:
-            args.append(f"schedule_ticks := {model.schedule_ticks}")
+            args.append(
+                sql.SQL("schedule_ticks := {val}").format(
+                    val=sql.Literal(model.schedule_ticks)
+                )
+            )
         if model.options:
-            args.append(f"options := {repr(json.dumps(model.options))}")
-        sql = "SELECT ml_register_compute(" + ", ".join(args) + ")"
-        return sql
+            args.append(
+                sql.SQL("options := {val}").format(
+                    val=sql.Literal(json.dumps(model.options))
+                )
+            )
+        query = sql.SQL("SELECT ml_register_compute({args})").format(
+            args=sql.SQL(", ").join(args)
+        )
+        return query.as_string(None)
 
     raise TypeError("Unsupported model type")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pre-commit
 black
 flake8
 isort
+psycopg[binary]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -113,6 +113,35 @@ class TestParser(unittest.TestCase):
         self.assertEqual(stmt.kernel, "immune_scan")
         self.assertEqual(stmt.options["SHARED"], "1K")
 
+    def test_compile_sql_escapes_identifiers(self):
+        model = parser.TrainModel(
+            name="m",
+            algorithm="alg",
+            params=[],
+            source="weird;table",
+            target="tar;get",
+            features=["fe;ature"],
+        )
+        sql_str = parser.compile_sql(model)
+        self.assertIn('"weird;table"', sql_str)
+        self.assertIn('"fe;ature"', sql_str)
+        self.assertIn('"tar;get"', sql_str)
+
+    def test_compile_sql_escapes_compute_identifiers(self):
+        stmt = parser.ComputeKernel(
+            name="name;drop",
+            inputs=["in;put"],
+            output="out;put",
+            schedule_ticks=None,
+            kernel="ker;nel",
+            options=None,
+        )
+        sql_str = parser.compile_sql(stmt)
+        self.assertIn("'name;drop'", sql_str)
+        self.assertIn("'ker;nel'", sql_str)
+        self.assertIn("'in;put'", sql_str)
+        self.assertIn("'out;put'", sql_str)
+
 
 @given(
     model_name=st.text(


### PR DESCRIPTION
## Summary
- switch DSL SQL generation to psycopg.sql to quote identifiers and literals
- register `psycopg[binary]` dependency
- add tests ensuring unusual characters in identifiers are safely escaped

## Testing
- `python -m pytest tests/test_parser.py`
- `pre-commit run --files dsl/parser.py tests/test_parser.py requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6895503d16888328ade7ebb27cbbc92f