### PR TITLE
refactor: refine parse return type

### DIFF
--- a/dsl/cli.py
+++ b/dsl/cli.py
@@ -3,7 +3,7 @@ import sys
 
 from lark.exceptions import LarkError
 
-from .parser import compile_sql, parse
+from .parser import ComputeKernel, TrainModel, compile_sql, parse
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -25,7 +25,7 @@ def main(argv: list[str] | None = None) -> int:
         text = sys.stdin.read()
 
     try:
-        model = parse(text)
+        model: TrainModel | ComputeKernel = parse(text)
         sql = compile_sql(model)
     except LarkError as exc:
         print(f"Failed to parse DSL: {exc}", file=sys.stderr)

--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from lark import Lark, Transformer, v_args
 
@@ -299,10 +299,10 @@ class TreeToModel(Transformer):
         )
 
 
-def parse(text: str) -> Any:
+def parse(text: str) -> TrainModel | ComputeKernel:
     tree = _PARSER.parse(text)
     model = TreeToModel().transform(tree)
-    return model
+    return cast(TrainModel | ComputeKernel, model)
 
 
 def compile_sql(model: Any) -> str:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import cast
 
 from hypothesis import given
 from hypothesis import strategies as st
@@ -14,7 +15,7 @@ class TestParser(unittest.TestCase):
             "regularization=0.01) FROM transactions "
             "PREDICT is_fraud WITH FEATURES(amount, merchant_type)"
         )
-        model = parser.parse(text)
+        model = cast(parser.TrainModel, parser.parse(text))
         self.assertEqual(model.name, "fraud_detector")
         self.assertEqual(model.algorithm, "logistic_regression")
         self.assertEqual(model.source, "transactions")
@@ -28,7 +29,7 @@ class TestParser(unittest.TestCase):
             "TRAIN MODEL simple_model USING decision_tree FROM training_data "
             "PREDICT outcome WITH FEATURES(a, b)"
         )
-        model = parser.parse(text)
+        model = cast(parser.TrainModel, parser.parse(text))
         self.assertEqual(model.name, "simple_model")
         self.assertEqual(model.algorithm, "decision_tree")
         self.assertEqual(model.params, [])
@@ -44,7 +45,7 @@ class TestParser(unittest.TestCase):
             "VALIDATE USING cv(folds=5) OPTIMIZE FOR accuracy "
             "STOP WHEN accuracy > 0.9"
         )
-        model = parser.parse(text)
+        model = cast(parser.TrainModel, parser.parse(text))
         self.assertIsNotNone(model.split)
         self.assertAlmostEqual(model.split.ratios["training"], 0.7)
         self.assertIsNotNone(model.validate)
@@ -66,7 +67,7 @@ class TestParser(unittest.TestCase):
             'TRAIN MODEL m USING alg(num=1, rate=0.5, name="x") FROM t '
             "PREDICT y WITH FEATURES(a)"
         )
-        model = parser.parse(text)
+        model = cast(parser.TrainModel, parser.parse(text))
         self.assertEqual(
             model.params,
             [
@@ -81,7 +82,7 @@ class TestParser(unittest.TestCase):
             "TRAIN MODEL m USING alg(alpha=-0.1, depth=-5) FROM t "
             "PREDICT y WITH FEATURES(a)"
         )
-        model = parser.parse(text)
+        model = cast(parser.TrainModel, parser.parse(text))
         self.assertEqual(model.params, [("alpha", -0.1), ("depth", -5)])
 
     def test_balance_clause(self):
@@ -89,7 +90,7 @@ class TestParser(unittest.TestCase):
             "TRAIN MODEL m USING alg() FROM t PREDICT y WITH FEATURES(a) "
             "BALANCE CLASSES BY oversampling"
         )
-        model = parser.parse(text)
+        model = cast(parser.TrainModel, parser.parse(text))
         self.assertEqual(model.balance_method, "oversampling")
 
     def test_parse_compute(self):
@@ -97,7 +98,7 @@ class TestParser(unittest.TestCase):
             "COMPUTE add_vectors FROM table(foo, bar) INTO column(baz) "
             "USING vector_add BLOCK 256 GRID auto"
         )
-        stmt = parser.parse(text)
+        stmt = cast(parser.ComputeKernel, parser.parse(text))
         self.assertIsInstance(stmt, parser.ComputeKernel)
         self.assertEqual(stmt.name, "add_vectors")
         self.assertEqual(stmt.inputs, ["foo", "bar"])
@@ -108,7 +109,7 @@ class TestParser(unittest.TestCase):
 
     def test_parse_compute_every(self):
         text = "COMPUTE scan_peptides EVERY 1000 TICKS USING immune_scan SHARED 1K"
-        stmt = parser.parse(text)
+        stmt = cast(parser.ComputeKernel, parser.parse(text))
         self.assertEqual(stmt.schedule_ticks, 1000)
         self.assertEqual(stmt.kernel, "immune_scan")
         self.assertEqual(stmt.options["SHARED"], "1K")
@@ -136,7 +137,7 @@ def test_property_based_parse(model_name, algorithm, source, target, feature):
         f"TRAIN MODEL {model_name} USING {algorithm} FROM {source} "
         f"PREDICT {target} WITH FEATURES({feature})"
     )
-    model = parser.parse(text)
+    model = cast(parser.TrainModel, parser.parse(text))
     assert model.name == model_name
     assert model.algorithm == algorithm
 


### PR DESCRIPTION
## Summary
- refine `parse` to return `TrainModel | ComputeKernel`
- type annotate CLI and tests for new parse union

## Testing
- `pre-commit run --files dsl/parser.py dsl/cli.py tests/test_parser.py`
- `mypy dsl tests`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68955038c0b883289f1c7bff40eb4c5b