### PR TITLE
Require at least one feature in DSL

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -38,7 +38,7 @@ param_list: param ("," param)*
 param: NAME "=" value
 value: SIGNED_NUMBER | ESCAPED_STRING | NAME
 
-features: "WITH" "FEATURES" "(" feature_list? ")"
+features: "WITH" "FEATURES" "(" feature_list ")"
 feature_list: NAME ("," NAME)*
 
 option: validate_stmt
@@ -159,7 +159,7 @@ class TreeToModel(Transformer):
         return list(items)
 
     def features(self, items):
-        return items[0] if items else []
+        return items[0]
 
     def option(self, items):
         return items[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -62,6 +62,11 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(LarkError):
             parser.parse(text)
 
+    def test_empty_feature_list(self):
+        text = "TRAIN MODEL m USING a FROM t PREDICT y WITH FEATURES()"
+        with self.assertRaises(LarkError):
+            parser.parse(text)
+
     def test_algorithm_param_types(self):
         text = (
             'TRAIN MODEL m USING alg(num=1, rate=0.5, name="x") FROM t '


### PR DESCRIPTION
## Summary
- Require at least one feature name in `WITH FEATURES` grammar
- Simplify feature list transformation
- Validate empty feature list is rejected in parser tests

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c15831848328b3dc00807c3bc0d5