### PR TITLE
Handle ValueError in DSL CLI

### DIFF
--- a/dsl/cli.py
+++ b/dsl/cli.py
@@ -34,8 +34,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         model: TrainModel | ComputeKernel = parse(text)
         sql = compile_sql(model)
-    except LarkError as exc:
-        print(f"Failed to parse DSL: {exc}", file=sys.stderr)
+    except (LarkError, ValueError) as exc:
+        print(f"Failed to compile DSL: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # pragma: no cover - safety net
+        print(f"Unexpected error: {exc}", file=sys.stderr)
         return 1
 
     # Print the generated SQL with a trailing newline to ensure a clean output


### PR DESCRIPTION
## Summary
- handle `ValueError` from `parse`/`compile_sql` in CLI
- add generic exception fallback for unexpected errors

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c15511e483288fe1900d8b903a49