### PR TITLE
Handle non-identifier sources when compiling training SQL

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -485,11 +485,16 @@ def compile_sql(model: TrainModel | ComputeKernel) -> str:
                 select_fields.append(sql.SQL(feature))
 
         select_fields.append(sql.Identifier(model.target))
+        if model.source_is_identifier:
+            source_fragment: sql.Composable = sql.Identifier(model.source)
+        else:
+            source_fragment = _as_sql_fragment(model.source)
+
         training_query = (
             sql.SQL("SELECT {fields} FROM {source}")
             .format(
                 fields=sql.SQL(", ").join(select_fields),
-                source=sql.Identifier(model.source),
+                source=source_fragment,
             )
             .as_string(None)
         )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -54,6 +54,10 @@ class TestParser(unittest.TestCase):
         self.assertFalse(model.source_is_identifier)
         sql_str = parser.compile_sql(model)
         self.assertIn("JOIN merchants", sql_str)
+        self.assertNotIn(
+            'FROM "transactions JOIN merchants ON transactions.merchant_id = merchants.id"',
+            sql_str,
+        )
 
     def test_parse_train_model_filtered_source(self):
         text = (
@@ -68,6 +72,10 @@ class TestParser(unittest.TestCase):
         self.assertFalse(model.source_is_identifier)
         sql_str = parser.compile_sql(model)
         self.assertIn("FROM (SELECT * FROM base WHERE active = TRUE) sub", sql_str)
+        self.assertNotIn(
+            'FROM "(SELECT * FROM base WHERE active = TRUE) sub"',
+            sql_str,
+        )
 
     def test_parse_train_model_with_options(self):
         text = (


### PR DESCRIPTION
## Summary
- respect `TrainModel.source_is_identifier` when selecting the SQL fragment for the FROM clause
- avoid quoting complex sources by formatting joins and subqueries with `_as_sql_fragment`
- extend parser tests to ensure complex sources compile without being quoted as a single identifier

## Testing
- PYTHONPATH=. pytest tests/test_parser.py


------
https://chatgpt.com/codex/tasks/task_e_69020ce83bc48328a078bfde332b5f9d