### PR TITLE
Raise minimum Python version requirement to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ our first prototypes.
 - **CockroachDB** for distributed coordination (optional for local
   experimentation)
 - **Rust** toolchain for building the DSL compiler
-- **Python 3.9+** for running the CLI and tests
+- **Python 3.10+** for running the CLI and tests
 
 ### Building and Running
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "DeclarativeML DSL compiler"
 authors = [{name = "DeclarativeML", email = "noreply@example.com"}]
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "lark",
     "psycopg[binary]"


### PR DESCRIPTION
## Summary
- bump the project metadata to require Python 3.10 or newer
- update the README prerequisites to match the new minimum Python version

## Testing
- `PYTHONPATH=. pytest` *(fails: packaging test expects a single top-level package and parser subquery formatting assertion)*

------
https://chatgpt.com/codex/tasks/task_e_69020ceb18148328be13a59867421581