### PR TITLE
Harden SQL source and feature expression compilation

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -117,8 +117,56 @@ SQL_CLAUSE: /(.|\n)+?(?=PREDICT\b)/
 # instantiate the parser once at module import time
 _PARSER = Lark(dsl_grammar, start="start", parser="lalr")
 
+_FEATURE_EXPR_PARSER = Lark(
+    r"""
+?start: feature_expr
+
+?feature_expr: feature_sum
+?feature_sum: feature_sum "+" feature_term   -> feature_add
+           | feature_sum "-" feature_term   -> feature_sub
+           | feature_term
+?feature_term: feature_term "*" feature_factor -> feature_mul
+             | feature_term "/" feature_factor -> feature_div
+             | feature_factor
+?feature_factor: "-" feature_factor         -> feature_neg
+               | feature_primary
+?feature_primary: feature_call
+                | feature_identifier
+                | feature_number
+                | feature_string
+                | "(" feature_expr ")"    -> feature_group
+
+feature_call: feature_identifier "(" feature_call_args? ")"
+feature_call_args: feature_call_arg ("," feature_call_arg)*
+feature_call_arg: NAME "=" feature_expr     -> feature_kwarg
+                | feature_expr
+feature_identifier: NAME ("." NAME)*
+feature_number: SIGNED_NUMBER
+feature_string: ESCAPED_STRING
+
+%import common.CNAME -> NAME
+%import common.SIGNED_NUMBER
+%import common.ESCAPED_STRING
+%import common.WS
+%ignore WS
+""",
+    start="start",
+    parser="lalr",
+)
+
 
 _SIMPLE_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_RELATION_IDENTIFIER_RE = re.compile(
+    r'[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*|"(?:[^"]|"")+"'
+)
+_FORBIDDEN_SOURCE_TOKENS_RE = re.compile(
+    r"\b("
+    r"INSERT|UPDATE|DELETE|UPSERT|MERGE|CREATE|ALTER|DROP|TRUNCATE|GRANT|REVOKE|"
+    r"BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE|LOCK|CALL|DO|EXECUTE|PREPARE|"
+    r"DEALLOCATE|COPY|VACUUM|ANALYZE|REFRESH|SET|SHOW|RESET|LISTEN|UNLISTEN|NOTIFY"
+    r")\b",
+    re.IGNORECASE,
+)
 
 
 def _as_sql_fragment(text: str) -> sql.SQL:
@@ -292,15 +340,8 @@ class TreeToModel(Transformer):
         return str(value)
 
     def feature_string(self, items):
-        (token,) = items
-        raw = token.value if hasattr(token, "value") else str(token)
-        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {'"', "'"}:
-            # Convert the token contents to a Python string so escape sequences are handled
-            string_value = json.loads(raw)
-        else:
-            string_value = json.loads(f'"{raw}"')
-        escaped = string_value.replace('"', '""')
-        return f'"{escaped}"'
+        (value,) = items
+        return f'"{value}"'
 
     def feature_kwarg(self, items):
         name, value = items
@@ -507,6 +548,120 @@ def _looks_like_single_identifier(clause: str) -> bool:
     return True
 
 
+def _validate_source_clause(clause: str) -> None:
+    """Validate non-identifier FROM source fragments to prevent SQL injection."""
+
+    if not clause:
+        raise ValueError("Training data source clause cannot be empty")
+    if ";" in clause:
+        raise ValueError("Training data source must not contain statement terminators")
+    if "--" in clause or "/*" in clause or "*/" in clause:
+        raise ValueError("Training data source must not contain SQL comments")
+    if _FORBIDDEN_SOURCE_TOKENS_RE.search(clause):
+        raise ValueError("Training data source contains disallowed SQL keywords")
+
+    text = clause.strip()
+    if text.startswith("("):
+        if not re.fullmatch(
+            r"\(\s*SELECT\b[\s\S]+\)\s*(?:AS\s+)?[A-Za-z_][A-Za-z0-9_]*\s*",
+            text,
+            flags=re.IGNORECASE,
+        ):
+            raise ValueError(
+                "Training data subqueries must be parenthesized SELECT statements with an alias"
+            )
+        return
+
+    relation_identifier = rf"(?:{_RELATION_IDENTIFIER_RE.pattern})"
+    relation_pattern = (
+        rf"^{relation_identifier}"
+        rf"(?:\s+(?:AS\s+)?[A-Za-z_][A-Za-z0-9_]*)?"
+        rf"(?:\s+(?:(?:INNER|LEFT|RIGHT|FULL|CROSS)\s+)?JOIN\s+{relation_identifier}"
+        rf"(?:\s+(?:AS\s+)?[A-Za-z_][A-Za-z0-9_]*)?\s+ON\s+[\w\s\.\(\)=<>!+\-*/'\"%]+)*"
+        rf"(?:\s+WHERE\s+[\w\s\.\(\)=<>!+\-*/'\"%]+)?"
+        rf"(?:\s+GROUP\s+BY\s+[\w\s\.,\(\)]+)?"
+        rf"(?:\s+HAVING\s+[\w\s\.\(\)=<>!+\-*/'\"%]+)?"
+        rf"(?:\s+ORDER\s+BY\s+[\w\s\.,\(\)]+)?"
+        rf"(?:\s+LIMIT\s+\d+)?"
+        rf"\s*$"
+    )
+    if not re.fullmatch(relation_pattern, text, flags=re.IGNORECASE):
+        raise ValueError(
+            "Training data source must be a relation/join expression or a parenthesized subquery"
+        )
+
+
+class _FeatureSqlCompiler(Transformer):
+    def NAME(self, token):
+        return str(token)
+
+    def SIGNED_NUMBER(self, token):
+        text = str(token)
+        return float(text) if "." in text else int(text)
+
+    def ESCAPED_STRING(self, token):
+        return json.loads(str(token))
+
+    def feature_identifier(self, items):
+        identifiers = [sql.Identifier(part) for part in items]
+        return sql.SQL(".").join(identifiers)
+
+    def feature_number(self, items):
+        (value,) = items
+        return sql.Literal(value)
+
+    def feature_string(self, items):
+        (value,) = items
+        return sql.Literal(value)
+
+    def feature_group(self, items):
+        (inner,) = items
+        return sql.SQL("({inner})").format(inner=inner)
+
+    def feature_add(self, items):
+        left, right = items
+        return sql.SQL("({left} + {right})").format(left=left, right=right)
+
+    def feature_sub(self, items):
+        left, right = items
+        return sql.SQL("({left} - {right})").format(left=left, right=right)
+
+    def feature_mul(self, items):
+        left, right = items
+        return sql.SQL("({left} * {right})").format(left=left, right=right)
+
+    def feature_div(self, items):
+        left, right = items
+        return sql.SQL("({left} / {right})").format(left=left, right=right)
+
+    def feature_neg(self, items):
+        (value,) = items
+        return sql.SQL("(-{value})").format(value=value)
+
+    def feature_kwarg(self, items):
+        name, value = items
+        return sql.SQL("{name} => {value}").format(name=sql.Identifier(name), value=value)
+
+    def feature_call_args(self, items):
+        return items
+
+    def feature_call_arg(self, items):
+        return items[0]
+
+    def feature_call(self, items):
+        name = items[0]
+        args = items[1] if len(items) > 1 else []
+        return sql.SQL("{name}({args})").format(name=name, args=sql.SQL(", ").join(args))
+
+
+def _compile_feature_expression(feature: str) -> sql.Composable:
+    try:
+        tree = _FEATURE_EXPR_PARSER.parse(feature)
+        return _FeatureSqlCompiler().transform(tree)
+    except Exception as exc:
+        raise ValueError(f"Invalid feature expression: {feature}") from exc
+
+
 def compile_sql(model: TrainModel | ComputeKernel) -> str:
     import json
 
@@ -516,16 +671,18 @@ def compile_sql(model: TrainModel | ComputeKernel) -> str:
         for feature in model.features:
             if _SIMPLE_IDENTIFIER_RE.fullmatch(feature):
                 select_fields.append(sql.Identifier(feature))
-            elif "." in feature or any(ch in feature for ch in " ()+-*/="):
-                select_fields.append(sql.SQL(feature))
             else:
-                select_fields.append(sql.Identifier(feature))
+                select_fields.append(_compile_feature_expression(feature))
 
         select_fields.append(sql.Identifier(model.target))
         if model.source_is_identifier:
             source_fragment: sql.Composable = sql.Identifier(model.source)
         else:
-            source_fragment = _as_sql_fragment(model.source)
+            if _looks_like_single_identifier(model.source):
+                source_fragment = sql.Identifier(model.source)
+            else:
+                _validate_source_clause(model.source)
+                source_fragment = _as_sql_fragment(model.source)
 
         training_query = (
             sql.SQL("SELECT {fields} FROM {source}")
@@ -639,4 +796,3 @@ def compile_sql(model: TrainModel | ComputeKernel) -> str:
         return query.as_string(None)
 
     raise TypeError("Unsupported model type")
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -115,15 +115,14 @@ class TestParser(unittest.TestCase):
             'PREDICT target WITH FEATURES("text \\"with\\" quotes")'
         )
         model = cast(parser.TrainModel, parser.parse(text))
-        self.assertEqual(model.features, ['"text ""with"" quotes"'])
+        self.assertEqual(model.features, ['"text \\"with\\" quotes"'])
 
         sql = parser.compile_sql(model)
         match = re.search(r"feature_columns := ARRAY\[\s*(?:E)?'([^']*)'\]", sql)
         self.assertIsNotNone(match)
         literal_body = match.group(1)
         decoded = literal_body.encode("utf-8").decode("unicode_escape")
-        final_literal = decoded.replace('\\"', '"')
-        self.assertEqual('"text ""with"" quotes"', final_literal)
+        self.assertEqual('"text \\"with\\" quotes"', decoded)
 
     def test_compile_sql_with_feature_expressions(self):
         model = parser.TrainModel(
@@ -157,8 +156,7 @@ class TestParser(unittest.TestCase):
         self.assertIsNotNone(match)
         training_query = match.group(1)
         self.assertIn('"amount"', training_query)
-        self.assertIn("customer.age", training_query)
-        self.assertNotIn('"customer.age"', training_query)
+        self.assertIn('"customer"."age"', training_query)
 
     def test_compile_sql_with_operator_expression(self):
         model = parser.TrainModel(
@@ -174,7 +172,7 @@ class TestParser(unittest.TestCase):
         self.assertIsNotNone(match)
         training_query = match.group(1)
         self.assertIn('"amount"', training_query)
-        self.assertIn("amount + tax", training_query)
+        self.assertIn('("amount" + "tax")', training_query)
         self.assertNotIn('"amount + tax"', training_query)
 
     def test_invalid_syntax_raises(self):
@@ -340,10 +338,8 @@ class TestParser(unittest.TestCase):
             target="tar;get",
             features=["fe;ature"],
         )
-        sql_str = parser.compile_sql(model)
-        self.assertIn('"weird;table"', sql_str)
-        self.assertIn('"fe;ature"', sql_str)
-        self.assertIn('"tar;get"', sql_str)
+        with self.assertRaises(ValueError):
+            parser.compile_sql(model)
 
     def test_compile_sql_quotes_single_table_with_punctuation(self):
         model = parser.TrainModel(
@@ -357,6 +353,73 @@ class TestParser(unittest.TestCase):
         )
         sql_str = parser.compile_sql(model)
         self.assertIn('FROM "user-events"', sql_str)
+
+    def test_compile_sql_blocks_unsafe_source_semicolon(self):
+        model = parser.TrainModel(
+            name="m",
+            algorithm="alg",
+            params=[],
+            source="transactions; DROP TABLE users",
+            target="target",
+            features=["feature"],
+            source_is_identifier=False,
+        )
+        with self.assertRaises(ValueError):
+            parser.compile_sql(model)
+
+    def test_compile_sql_blocks_unsafe_source_keywords(self):
+        model = parser.TrainModel(
+            name="m",
+            algorithm="alg",
+            params=[],
+            source="transactions WHERE 1=1 COMMIT",
+            target="target",
+            features=["feature"],
+            source_is_identifier=False,
+        )
+        with self.assertRaises(ValueError):
+            parser.compile_sql(model)
+
+    def test_compile_sql_allows_safe_join_source(self):
+        model = parser.TrainModel(
+            name="m",
+            algorithm="alg",
+            params=[],
+            source="transactions t JOIN merchants m ON t.merchant_id = m.id WHERE t.amount > 0",
+            target="target",
+            features=["t.amount", "m.category"],
+            source_is_identifier=False,
+        )
+        sql_str = parser.compile_sql(model)
+        self.assertIn("JOIN merchants m ON t.merchant_id = m.id", sql_str)
+        self.assertIn('"t"."amount"', sql_str)
+
+    def test_compile_sql_allows_safe_parenthesized_subquery(self):
+        model = parser.TrainModel(
+            name="m",
+            algorithm="alg",
+            params=[],
+            source="(SELECT * FROM transactions WHERE amount > 10) tx",
+            target="target",
+            features=["amount * 2", "sqrt(amount + 1)"],
+            source_is_identifier=False,
+        )
+        sql_str = parser.compile_sql(model)
+        self.assertIn("FROM (SELECT * FROM transactions WHERE amount > 10) tx", sql_str)
+        self.assertIn('("amount" * 2)', sql_str)
+        self.assertIn('"sqrt"(("amount" + 1))', sql_str)
+
+    def test_compile_sql_blocks_unsafe_feature_expression(self):
+        model = parser.TrainModel(
+            name="m",
+            algorithm="alg",
+            params=[],
+            source="source_table",
+            target="target_col",
+            features=["amount", "amount; DROP TABLE users"],
+        )
+        with self.assertRaises(ValueError):
+            parser.compile_sql(model)
 
     def test_compile_sql_includes_checkpoint(self):
         model = parser.TrainModel(


### PR DESCRIPTION
### Motivation
- Prevent untrusted text in `TrainModel.source` and feature definitions from being interpolated as arbitrary multi-statement SQL that could enable injection or control-flow commands.
- Enforce a safer, well-scoped grammar for feature expressions so only AST-safe constructs are allowed instead of accepting arbitrary operator-containing strings.
- Keep using `psycopg.sql` composition for safe quoting while adding defensive validation and compilation steps around untrusted fragments.

### Description
- Added a dedicated feature-expression parser (`_FEATURE_EXPR_PARSER`) and SQL-emitting transformer (`_FeatureSqlCompiler`) that compile feature expressions into `psycopg.sql` composables rather than inserting raw text. (changes in `dsl/parser.py`).
- Introduced `_validate_source_clause` to reject statement terminators, SQL comments, and disallowed transaction/control keywords, and to only allow either parenthesized `SELECT` subqueries with alias or a relation/join grammar for non-identifier `FROM` fragments. (changes in `dsl/parser.py`).
- Updated the top-level `compile_sql` to use the new feature compiler for non-simple identifiers and to run source validation before embedding non-identifier sources via `_as_sql_fragment`.
- Adjusted the DSL transformer feature-string handling and updated tests to reflect the safer encoding/compilation approach and stricter behavior. (changes in `dsl/parser.py` and `tests/test_parser.py`).

### Testing
- Added/updated unit tests in `tests/test_parser.py` that assert unsafe `source` payloads (e.g. containing `;` or control keywords) are blocked, and that safe join/relation forms and parenthesized subqueries are allowed; tests also cover blocked unsafe feature expressions.
- Ran the parser test suite with `PYTHONPATH=. pytest -q tests/test_parser.py` and all tests passed (`37 passed`).
- The changes exercise both parsing and compilation paths and verify that emitted SQL uses `psycopg.sql` composables while preventing untrusted text from becoming executable multi-statement SQL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e282b45c488328b2534797d86357b5)