### PR TITLE
Validate compute BLOCK/SHARED/GRID parser options

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -119,6 +119,8 @@ _PARSER = Lark(dsl_grammar, start="start", parser="lalr")
 
 
 _SIMPLE_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_SHARED_SIZE_RE = re.compile(r"^(0|[1-9][0-9]*)([KMG])?$")
+_GRID_ALLOWED_VALUES = {"auto"}
 
 
 def _as_sql_fragment(text: str) -> sql.SQL:
@@ -349,13 +351,34 @@ class TreeToModel(Transformer):
         return items[0]
 
     def block_opt(self, items):
-        return ("BLOCK", items[0])
+        value = items[0]
+
+        if isinstance(value, float):
+            if not value.is_integer():
+                raise ValueError("block size must be a positive integer")
+            value = int(value)
+        elif not isinstance(value, int):
+            raise ValueError("block size must be a positive integer")
+
+        if value <= 0:
+            raise ValueError("block size must be a positive integer")
+
+        return ("BLOCK", value)
 
     def grid_opt(self, items):
-        return ("GRID", items[0])
+        value = items[0]
+        if value not in _GRID_ALLOWED_VALUES:
+            allowed_values = ", ".join(sorted(_GRID_ALLOWED_VALUES))
+            raise ValueError(f"grid value must be one of: {allowed_values}")
+        return ("GRID", value)
 
     def shared_opt(self, items):
-        return ("SHARED", items[0])
+        value = str(items[0])
+        if _SHARED_SIZE_RE.fullmatch(value) is None:
+            raise ValueError(
+                "shared memory size must be a non-negative integer optionally suffixed with K, M, or G"
+            )
+        return ("SHARED", value)
 
     def split_entry(self, items):
         name, value = items
@@ -639,4 +662,3 @@ def compile_sql(model: TrainModel | ComputeKernel) -> str:
         return query.as_string(None)
 
     raise TypeError("Unsupported model type")
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -287,6 +287,13 @@ class TestParser(unittest.TestCase):
         self.assertEqual(stmt.kernel, "immune_scan")
         self.assertEqual(stmt.options["SHARED"], "1K")
 
+    def test_parse_compute_valid_block_and_shared_edges(self):
+        text = "COMPUTE scan_peptides USING immune_scan BLOCK 1 SHARED 0 GRID auto"
+        stmt = cast(parser.ComputeKernel, parser.parse(text))
+        self.assertEqual(stmt.options["BLOCK"], 1)
+        self.assertEqual(stmt.options["SHARED"], "0")
+        self.assertEqual(stmt.options["GRID"], "auto")
+
     def test_parse_compute_every_fractional_ticks(self):
         text = "COMPUTE scan_peptides EVERY 10.5 TICKS USING immune_scan"
         with self.assertRaises(ValueError):
@@ -301,6 +308,39 @@ class TestParser(unittest.TestCase):
         text = "COMPUTE bad_job USING some_kernel EXTRA"
         with self.assertRaises(LarkError):
             parser.parse(text)
+
+    def test_parse_compute_invalid_block_values(self):
+        with self.assertRaisesRegex(ValueError, "block size must be a positive integer"):
+            parser.parse("COMPUTE bad_job USING some_kernel BLOCK 0")
+
+        with self.assertRaisesRegex(ValueError, "block size must be a positive integer"):
+            parser.parse("COMPUTE bad_job USING some_kernel BLOCK -2")
+
+        with self.assertRaisesRegex(ValueError, "block size must be a positive integer"):
+            parser.parse("COMPUTE bad_job USING some_kernel BLOCK 32.5")
+
+    def test_parse_compute_invalid_shared_values(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "shared memory size must be a non-negative integer optionally suffixed with K, M, or G",
+        ):
+            parser.parse("COMPUTE bad_job USING some_kernel SHARED -1")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "shared memory size must be a non-negative integer optionally suffixed with K, M, or G",
+        ):
+            parser.parse("COMPUTE bad_job USING some_kernel SHARED 1.5K")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "shared memory size must be a non-negative integer optionally suffixed with K, M, or G",
+        ):
+            parser.parse("COMPUTE bad_job USING some_kernel SHARED 2KB")
+
+    def test_parse_compute_invalid_grid_values(self):
+        with self.assertRaisesRegex(ValueError, "grid value must be one of: auto"):
+            parser.parse("COMPUTE bad_job USING some_kernel GRID manual")
 
     def test_compute_stmt_unexpected_part(self):
         transformer = parser.TreeToModel()


### PR DESCRIPTION
### Motivation
- Ensure compute kernel options are validated early in the parser so malformed values for `BLOCK`, `SHARED`, or `GRID` produce clear, consistent `ValueError` messages.
- Prevent downstream misuses by enforcing intended types and formats for memory sizes and grid settings.

### Description
- Enforced that `BLOCK` is a strictly positive integer in `TreeToModel.block_opt`, rejecting `0`, negatives, and non-integer floats and raising `ValueError("block size must be a positive integer")` on failure.
- Added `_SHARED_SIZE_RE` and validated `SHARED` in `TreeToModel.shared_opt` to accept only non-negative integers optionally suffixed with `K`, `M`, or `G` (e.g., `0`, `1K`, `256M`) and raised `ValueError("shared memory size must be a non-negative integer optionally suffixed with K, M, or G")` on invalid inputs.
- Added `_GRID_ALLOWED_VALUES = {"auto"}` and validated `GRID` in `TreeToModel.grid_opt`, raising `ValueError(f"grid value must be one of: {allowed_values}")` for unsupported values.
- Added unit tests in `tests/test_parser.py` covering valid edge cases and invalid `BLOCK`, `SHARED`, and `GRID` inputs, and asserting on the exact `ValueError` messages.

### Testing
- Ran targeted compute-related tests with `PYTHONPATH=. pytest -q tests/test_parser.py -k 'compute and (block or shared or grid or valid_block_and_shared_edges)'`, and the targeted tests passed (`4 passed`).
- Ran the full parser test file with `PYTHONPATH=. pytest -q tests/test_parser.py`, which exercised the new tests but reported one unrelated existing failure in `test_compile_sql_quotes_single_table_with_punctuation` (the failure is unrelated to the `BLOCK/SHARED/GRID` validations).
- All added tests for `BLOCK/SHARED/GRID` validation passed when run in isolation as shown above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e282b698dc83289f63c5cc5859cc33)