### PR TITLE
Unify TrainModel.source identifier detection and add boundary tests

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -127,6 +127,28 @@ def _as_sql_fragment(text: str) -> sql.SQL:
     return sql.SQL(text.replace("{", "{{").replace("}", "}}"))
 
 
+def _is_identifier_source_clause(clause: str) -> bool:
+    """Return True only for a single unqualified, unquoted source identifier.
+
+    Accepted form:
+      - A single token without whitespace/dots/parentheses/quotes, such as
+        ``transactions``, ``training_data_2026``, or ``user-events``.
+
+    Rejected forms (compiled in SQL fragment mode instead):
+      - Schema-qualified names such as ``analytics.transactions``.
+      - Quoted identifiers such as ``"Transactions"``.
+      - Joins/subqueries/expressions such as ``a JOIN b`` or ``(SELECT ...) t``.
+    """
+
+    if not clause:
+        return False
+    if any(ch.isspace() for ch in clause):
+        return False
+    if any(ch in '.()"\\\'' for ch in clause):
+        return False
+    return True
+
+
 @dataclass
 class DataSplit:
     ratios: Dict[str, float]
@@ -419,7 +441,7 @@ class TreeToModel(Transformer):
         source_clause = source.strip() if isinstance(source, str) else str(source).strip()
         if not source_clause:
             raise ValueError("Training data source clause cannot be empty")
-        source_is_identifier = bool(_SIMPLE_IDENTIFIER_RE.fullmatch(source_clause))
+        source_is_identifier = _is_identifier_source_clause(source_clause)
         model = TrainModel(
             name=model_name,
             algorithm=alg_name,
@@ -491,20 +513,6 @@ def parse(text: str) -> TrainModel | ComputeKernel:
             raise e.orig_exc
         raise
     return model
-
-
-def _looks_like_single_identifier(clause: str) -> bool:
-    """Heuristically determine if a source clause should be treated as one identifier."""
-
-    if not clause:
-        return False
-    if any(ch.isspace() for ch in clause):
-        return False
-    if any(ch in ".()" for ch in clause):
-        return False
-    if clause[0] == "\"" and clause[-1] == "\"":
-        return False
-    return True
 
 
 def compile_sql(model: TrainModel | ComputeKernel) -> str:
@@ -639,4 +647,3 @@ def compile_sql(model: TrainModel | ComputeKernel) -> str:
         return query.as_string(None)
 
     raise TypeError("Unsupported model type")
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -41,6 +41,64 @@ class TestParser(unittest.TestCase):
         self.assertEqual(model.features, ["a", "b"])
         self.assertTrue(model.source_is_identifier)
 
+    def test_parse_train_model_source_identifier_boundaries(self):
+        cases = [
+            ("transactions", True),
+            ("analytics.transactions", False),
+            ('"Transactions"', False),
+            ("transactions JOIN merchants ON transactions.id = merchants.id", False),
+            ("(SELECT * FROM transactions) t", False),
+        ]
+        for source, expected in cases:
+            with self.subTest(source=source):
+                text = (
+                    f"TRAIN MODEL m USING alg FROM {source} "
+                    "PREDICT y WITH FEATURES(a)"
+                )
+                model = cast(parser.TrainModel, parser.parse(text))
+                self.assertEqual(model.source, source)
+                self.assertEqual(model.source_is_identifier, expected)
+
+    def test_compile_sql_uses_identifier_mode_for_simple_source(self):
+        model = parser.TrainModel(
+            name="m",
+            algorithm="alg",
+            params=[],
+            source="transactions",
+            target="y",
+            features=["a"],
+            source_is_identifier=True,
+        )
+        sql_str = parser.compile_sql(model)
+        self.assertIn('FROM "transactions"', sql_str)
+
+    def test_compile_sql_uses_fragment_mode_for_dotted_source(self):
+        model = parser.TrainModel(
+            name="m",
+            algorithm="alg",
+            params=[],
+            source="analytics.transactions",
+            target="y",
+            features=["a"],
+            source_is_identifier=False,
+        )
+        sql_str = parser.compile_sql(model)
+        self.assertIn("FROM analytics.transactions", sql_str)
+        self.assertNotIn('FROM "analytics.transactions"', sql_str)
+
+    def test_compile_sql_uses_fragment_mode_for_quoted_source(self):
+        model = parser.TrainModel(
+            name="m",
+            algorithm="alg",
+            params=[],
+            source='"Transactions"',
+            target="y",
+            features=["a"],
+            source_is_identifier=False,
+        )
+        sql_str = parser.compile_sql(model)
+        self.assertIn('FROM "Transactions"', sql_str)
+
     def test_parse_train_model_join_source(self):
         text = (
             "TRAIN MODEL joined USING alg FROM transactions JOIN merchants ON "
@@ -353,7 +411,7 @@ class TestParser(unittest.TestCase):
             source="user-events",
             target="target",
             features=["feature"],
-            source_is_identifier=False,
+            source_is_identifier=True,
         )
         sql_str = parser.compile_sql(model)
         self.assertIn('FROM "user-events"', sql_str)


### PR DESCRIPTION
### Motivation
- Remove duplicated heuristics and centralize the decision of whether `TrainModel.source` should be treated as a SQL identifier vs a SQL fragment. 
- Make the accepted identifier forms explicit so SQL compilation (`sql.Identifier` vs fragment mode) is deterministic and documented.

### Description
- Add `_is_identifier_source_clause(clause: str)` helper in `dsl/parser.py` with docstring explaining accepted forms (single unqualified, unquoted token) and rejected forms (schema-qualified dotted names, quoted identifiers, joins, subqueries, expressions). 
- Use `_is_identifier_source_clause` from the `train_stmt` transformer to set `TrainModel.source_is_identifier`. 
- Remove the obsolete duplicate heuristic `_looks_like_single_identifier` (now unused). 
- Add boundary tests in `tests/test_parser.py` that assert `source_is_identifier` and compilation behavior for: simple name, dotted (schema-qualified) name, quoted identifier, join clause, and subquery. 
- Add tests that verify `compile_sql` chooses `sql.Identifier(...)` when `source_is_identifier=True` and fragment mode when `False`, and update an existing punctuation test to reflect the chosen identifier behavior.

### Testing
- Ran `python -m py_compile dsl/parser.py` to validate syntax (no errors). 
- Ran the parser unit tests with `PYTHONPATH=. pytest -q tests/test_parser.py`, which completed successfully: all tests passed (`36 passed, 5 subtests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e282b7ebe883289ab65c793d2738a6)