### PR TITLE
Stop eager CLI import in dsl package initialization

### DIFF
--- a/dsl/__init__.py
+++ b/dsl/__init__.py
@@ -1,6 +1,5 @@
 """DSL parsing and compilation utilities."""
 
-from . import cli
 from .parser import ComputeKernel, TrainModel, compile_sql, parse
 
-__all__ = ["TrainModel", "ComputeKernel", "parse", "compile_sql", "cli"]
+__all__ = ["TrainModel", "ComputeKernel", "parse", "compile_sql"]

--- a/tests/test_import_behavior.py
+++ b/tests/test_import_behavior.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_import_dsl_is_side_effect_minimal() -> None:
+    project_root = Path(__file__).resolve().parent.parent
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, sys; "
+                "import dsl; "
+                "print(json.dumps({"
+                "'has_cli_module': 'dsl.cli' in sys.modules, "
+                "'all': dsl.__all__"
+                "}))"
+            ),
+        ],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout.strip())
+    assert payload["has_cli_module"] is False
+    assert payload["all"] == ["TrainModel", "ComputeKernel", "parse", "compile_sql"]


### PR DESCRIPTION
### Motivation
- Avoid side effects on `import dsl` by preventing the package init from eagerly importing the CLI module so consumers get only the parser/compiler API by default.

### Description
- Removed the top-level `from . import cli` import from `dsl/__init__.py`.
- Narrowed `__all__` to `['TrainModel', 'ComputeKernel', 'parse', 'compile_sql']` so the package export focuses on parser/compiler APIs and no longer exposes `cli`.
- Added `tests/test_import_behavior.py` which launches a clean Python subprocess that `import`s `dsl` and asserts that `dsl.cli` is not present in `sys.modules` and that `dsl.__all__` matches the parser/compiler API list.

### Testing
- Ran `pytest -q tests/test_import_behavior.py tests/test_cli.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e282babdac832880e633bc31fbab45)