### PR TITLE
Strengthen SQL contract assertions in parser and CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,24 @@ import tempfile
 import unittest
 
 
+def _extract_named_arg(sql_text: str, arg_name: str) -> str:
+    escaped_name = re.escape(arg_name)
+    match = re.search(
+        rf"(?<![A-Za-z0-9_]){escaped_name}(?![A-Za-z0-9_])\s*:=\s*"
+        rf"(?P<value>ARRAY\[(?:.|\n)*?\]|'(?:''|[^'])*'|-?\d+(?:\.\d+)?)\s*(?:,|\))",
+        sql_text,
+    )
+    if not match:
+        raise AssertionError(f"Argument '{arg_name}' not found in SQL: {sql_text}")
+    return match.group("value")
+
+
+def _decode_sql_string_literal(value: str) -> str:
+    if len(value) < 2 or value[0] != "'" or value[-1] != "'":
+        raise AssertionError(f"Expected SQL string literal, got: {value}")
+    return value[1:-1].replace("''", "'")
+
+
 class TestCLI(unittest.TestCase):
     def test_cli_stdin(self):
         repo_root = os.path.dirname(os.path.dirname(__file__))
@@ -105,16 +123,116 @@ class TestCLI(unittest.TestCase):
         )
         output = result.stdout.decode()
         self.assertIn("ml_train_model", output)
-
-        match = re.search(r"algorithm_params := '([^']*)'", output)
-        self.assertIsNotNone(match)
-        params = json.loads(match.group(1))
+        params = json.loads(
+            _decode_sql_string_literal(_extract_named_arg(output, "algorithm_params"))
+        )
         self.assertEqual(
             params,
             {
                 "layers": [32, 16],
                 "config": {"mode": "fast", "thresholds": [0.1, 0.2]},
             },
+        )
+
+    def test_cli_train_with_split_validate_optimize_and_checkpoint(self):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        dsl_text = (
+            "TRAIN MODEL cli_contract USING decision_tree(max_depth=8) FROM train_data "
+            "PREDICT label WITH FEATURES(x, y) "
+            "SPLIT DATA training=0.7, validation=0.2, test=0.1 "
+            "VALIDATE USING cv(folds=4) OPTIMIZE FOR accuracy "
+            "SAVE CHECKPOINTS EVERY 5 epochs"
+        )
+        result = subprocess.run(
+            [sys.executable, "-m", "dsl.cli"],
+            input=dsl_text.encode(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=repo_root,
+            check=True,
+        )
+        output = result.stdout.decode()
+
+        # Smoke checks
+        self.assertIn("ml_train_model", output)
+        self.assertIn("model_name :=", output)
+        self.assertIn("training_data :=", output)
+
+        # Structure checks
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(output, "model_name")),
+            "cli_contract",
+        )
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(output, "training_data"))
+            .split(" FROM ")[-1],
+            '"train_data"',
+        )
+        self.assertEqual(
+            json.loads(
+                _decode_sql_string_literal(_extract_named_arg(output, "algorithm_params"))
+            ),
+            {"max_depth": 8},
+        )
+        self.assertEqual(
+            json.loads(_decode_sql_string_literal(_extract_named_arg(output, "data_split"))),
+            {"training": 0.7, "validation": 0.2, "test": 0.1},
+        )
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(output, "validate_method")),
+            "cv",
+        )
+        self.assertEqual(
+            json.loads(
+                _decode_sql_string_literal(_extract_named_arg(output, "validate_params"))
+            ),
+            {"folds": 4},
+        )
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(output, "optimize_metric")),
+            "accuracy",
+        )
+        self.assertEqual(
+            json.loads(
+                _decode_sql_string_literal(_extract_named_arg(output, "checkpoint_schedule"))
+            ),
+            {"interval": 5, "unit": "epochs"},
+        )
+
+    def test_cli_compute_with_schedule_and_options_contract(self):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        dsl_text = (
+            "COMPUTE scan_peptides EVERY 1000 TICKS USING immune_scan "
+            "BLOCK 256 GRID auto SHARED 1K"
+        )
+        result = subprocess.run(
+            [sys.executable, "-m", "dsl.cli"],
+            input=dsl_text.encode(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=repo_root,
+            check=True,
+        )
+        output = result.stdout.decode()
+
+        # Smoke checks
+        self.assertIn("ml_register_compute", output)
+        self.assertIn("schedule_ticks :=", output)
+        self.assertIn("options :=", output)
+
+        # Structure checks
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(output, "kernel_name")),
+            "immune_scan",
+        )
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(output, "name")),
+            "scan_peptides",
+        )
+        self.assertEqual(_extract_named_arg(output, "schedule_ticks"), "1000")
+        self.assertEqual(
+            json.loads(_decode_sql_string_literal(_extract_named_arg(output, "options"))),
+            {"BLOCK": 256, "GRID": "auto", "SHARED": "1K"},
         )
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,6 +10,24 @@ from lark.exceptions import LarkError
 from dsl import parser
 
 
+def _extract_named_arg(sql_text: str, arg_name: str) -> str:
+    escaped_name = re.escape(arg_name)
+    match = re.search(
+        rf"(?<![A-Za-z0-9_]){escaped_name}(?![A-Za-z0-9_])\s*:=\s*"
+        rf"(?P<value>ARRAY\[(?:.|\n)*?\]|'(?:''|[^'])*'|-?\d+(?:\.\d+)?)\s*(?:,|\))",
+        sql_text,
+    )
+    if not match:
+        raise AssertionError(f"Argument '{arg_name}' not found in SQL: {sql_text}")
+    return match.group("value")
+
+
+def _decode_sql_string_literal(value: str) -> str:
+    if len(value) < 2 or value[0] != "'" or value[-1] != "'":
+        raise AssertionError(f"Expected SQL string literal, got: {value}")
+    return value[1:-1].replace("''", "'")
+
+
 class TestParser(unittest.TestCase):
     def test_parse_train_model(self):
         text = (
@@ -236,9 +254,7 @@ class TestParser(unittest.TestCase):
             ],
         )
         sql = parser.compile_sql(model)
-        match = re.search(r"algorithm_params := '([^']*)'", sql)
-        self.assertIsNotNone(match)
-        params_json = match.group(1)
+        params_json = _decode_sql_string_literal(_extract_named_arg(sql, "algorithm_params"))
         self.assertEqual(
             json.loads(params_json),
             {
@@ -370,8 +386,108 @@ class TestParser(unittest.TestCase):
         )
         sql_str = parser.compile_sql(model)
         self.assertIn("checkpoint_schedule :=", sql_str)
-        self.assertIn('"interval": 5', sql_str)
-        self.assertIn('"unit": "epochs"', sql_str)
+        checkpoint_payload = json.loads(
+            _decode_sql_string_literal(_extract_named_arg(sql_str, "checkpoint_schedule"))
+        )
+        self.assertEqual(checkpoint_payload, {"interval": 5, "unit": "epochs"})
+
+    def test_compile_sql_train_structure_with_multiple_options(self):
+        model = parser.TrainModel(
+            name="fraud_v2",
+            algorithm="xgboost",
+            params=[("max_depth", 6), ("learning_rate", 0.1)],
+            source="transactions",
+            target="is_fraud",
+            features=["amount", "merchant_type"],
+            split=parser.DataSplit({"training": 0.7, "validation": 0.2, "test": 0.1}),
+            validate=parser.ValidationOption(method="cv", params=[("folds", 5)]),
+            optimize_metric="f1_score",
+            checkpoint=parser.CheckpointOption(interval=10, unit="epochs"),
+        )
+        sql_str = parser.compile_sql(model)
+
+        # Smoke checks
+        self.assertIn("ml_train_model", sql_str)
+        self.assertIn("model_name :=", sql_str)
+        self.assertIn("training_data :=", sql_str)
+
+        # Structure checks
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(sql_str, "model_name")),
+            "fraud_v2",
+        )
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(sql_str, "algorithm")),
+            "xgboost",
+        )
+
+        training_data = _decode_sql_string_literal(_extract_named_arg(sql_str, "training_data"))
+        self.assertIn('FROM "transactions"', training_data)
+        self.assertIn('"amount"', training_data)
+        self.assertIn('"merchant_type"', training_data)
+        self.assertIn('"is_fraud"', training_data)
+
+        self.assertEqual(
+            json.loads(
+                _decode_sql_string_literal(_extract_named_arg(sql_str, "algorithm_params"))
+            ),
+            {"max_depth": 6, "learning_rate": 0.1},
+        )
+        self.assertEqual(
+            json.loads(_decode_sql_string_literal(_extract_named_arg(sql_str, "data_split"))),
+            {"training": 0.7, "validation": 0.2, "test": 0.1},
+        )
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(sql_str, "validate_method")),
+            "cv",
+        )
+        self.assertEqual(
+            json.loads(
+                _decode_sql_string_literal(_extract_named_arg(sql_str, "validate_params"))
+            ),
+            {"folds": 5},
+        )
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(sql_str, "optimize_metric")),
+            "f1_score",
+        )
+        self.assertEqual(
+            json.loads(
+                _decode_sql_string_literal(_extract_named_arg(sql_str, "checkpoint_schedule"))
+            ),
+            {"interval": 10, "unit": "epochs"},
+        )
+
+    def test_compile_sql_compute_structure_with_schedule_and_options(self):
+        stmt = parser.ComputeKernel(
+            name="scan_peptides",
+            kernel="immune_scan",
+            inputs=["signal_a", "signal_b"],
+            output="risk_score",
+            schedule_ticks=1000,
+            options={"BLOCK": 256, "GRID": "auto", "SHARED": "1K"},
+        )
+        sql_str = parser.compile_sql(stmt)
+
+        # Smoke checks
+        self.assertIn("ml_register_compute", sql_str)
+        self.assertIn("schedule_ticks :=", sql_str)
+        self.assertIn("options :=", sql_str)
+
+        # Structure checks
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(sql_str, "kernel_name")),
+            "immune_scan",
+        )
+        self.assertEqual(
+            _decode_sql_string_literal(_extract_named_arg(sql_str, "name")),
+            "scan_peptides",
+        )
+        self.assertEqual(_extract_named_arg(sql_str, "schedule_ticks"), "1000")
+        self.assertEqual(
+            json.loads(_decode_sql_string_literal(_extract_named_arg(sql_str, "options"))),
+            {"BLOCK": 256, "GRID": "auto", "SHARED": "1K"},
+        )
 
     def test_compile_sql_escapes_compute_identifiers(self):
         stmt = parser.ComputeKernel(


### PR DESCRIPTION
### Motivation
- Make tests validate the structured SQL payload produced by the compiler instead of relying on fragile substring checks.
- Ensure fields that carry JSON (like `algorithm_params`, `options`, `checkpoint_schedule`) are decoded and compared as dictionaries to catch regressions in argument encoding.
- Add coverage for combined option permutations (split + validate + optimize + checkpoint) and compute scheduling/options combinations to lock down core compiler contracts.

### Description
- Added reusable helpers `_extract_named_arg(sql_text, arg_name)` and `_decode_sql_string_literal(value)` to `tests/test_parser.py` and `tests/test_cli.py` to reliably extract named SQL arguments (e.g. `model_name :=`, `training_data :=`, `algorithm_params :=`) using regex with stable token boundaries and decode SQL single-quoted literals.
- Replaced fragile substring checks in several tests with structured assertions that decode JSON-bearing fields and compare to expected dicts for `algorithm_params`, `data_split`, `validate_params`, `checkpoint_schedule`, and `options`.
- Added parser-level contract tests: `test_compile_sql_train_structure_with_multiple_options` and `test_compile_sql_compute_structure_with_schedule_and_options` which include smoke checks and deep structure checks of SQL arguments.
- Added CLI-level end-to-end contract tests: `test_cli_train_with_split_validate_optimize_and_checkpoint` and `test_cli_compute_with_schedule_and_options_contract` that run the CLI and assert the structured payloads returned on stdout.

### Testing
- Ran targeted contract tests with `PYTHONPATH=. pytest -q tests/test_parser.py tests/test_cli.py -k 'structure or nested_params or includes_checkpoint or algorithm_param_list_and_dict_literals or train_with_split_validate_optimize_and_checkpoint or compute_with_schedule_and_options_contract'`, which passed (`7 passed, 35 deselected`).
- Running both test modules together with `PYTHONPATH=. pytest -q tests/test_parser.py tests/test_cli.py` surfaced a remaining unrelated, pre-existing failure in `test_compile_sql_quotes_single_table_with_punctuation` that was not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e282bb3a2083289b306b45e335596d)