### PR TITLE
Validate checkpoint schedule intervals in parser

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -458,6 +458,16 @@ class TreeToModel(Transformer):
 
     def checkpoint_stmt(self, items):
         interval = items[0]
+        if isinstance(interval, float):
+            if not interval.is_integer():
+                raise ValueError("checkpoint interval must be a positive integer")
+            interval = int(interval)
+        elif not isinstance(interval, int):
+            raise ValueError("checkpoint interval must be a positive integer")
+
+        if interval <= 0:
+            raise ValueError("checkpoint interval must be a positive integer")
+
         unit = items[1] if len(items) > 1 else None
         return CheckpointOption(interval=interval, unit=unit)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -338,6 +338,17 @@ class TestParser(unittest.TestCase):
         self.assertEqual(model.checkpoint.interval, 10)
         self.assertEqual(model.checkpoint.unit, "epochs")
 
+    def test_checkpoint_clause_invalid_intervals(self):
+        for interval in ("0", "-1", "2.5"):
+            text = (
+                "TRAIN MODEL m USING alg() FROM t PREDICT y WITH FEATURES(a) "
+                f"SAVE CHECKPOINTS EVERY {interval} epochs"
+            )
+            with self.assertRaisesRegex(
+                ValueError, "checkpoint interval must be a positive integer"
+            ):
+                parser.parse(text)
+
     def test_parse_compute(self):
         text = (
             "COMPUTE add_vectors FROM table(foo, bar) INTO column(baz) "
@@ -551,6 +562,18 @@ class TestParser(unittest.TestCase):
             _decode_sql_string_literal(_extract_named_arg(sql_str, "checkpoint_schedule"))
         )
         self.assertEqual(checkpoint_payload, {"interval": 5, "unit": "epochs"})
+
+    def test_compile_sql_includes_checkpoint_from_parsed_statement(self):
+        text = (
+            "TRAIN MODEL m USING alg() FROM data PREDICT target WITH FEATURES(feature) "
+            "SAVE CHECKPOINTS EVERY 10 epochs"
+        )
+        model = cast(parser.TrainModel, parser.parse(text))
+        sql_str = parser.compile_sql(model)
+        checkpoint_payload = json.loads(
+            _decode_sql_string_literal(_extract_named_arg(sql_str, "checkpoint_schedule"))
+        )
+        self.assertEqual(checkpoint_payload, {"interval": 10, "unit": "epochs"})
 
     def test_compile_sql_train_structure_with_multiple_options(self):
         model = parser.TrainModel(


### PR DESCRIPTION
### Motivation
- Ensure checkpoint schedule normalization matches existing `compute_every`/`block_opt` behavior so invalid or fractional checkpoint intervals are rejected early.
- Prevent downstream misbehavior by enforcing that checkpoint `interval` is a positive integer and by producing a clear error message for invalid inputs.

### Description
- Add normalization and validation in `TreeToModel.checkpoint_stmt` to reject non-integer floats, reject non-numeric types, coerce integer-like floats to `int`, and reject values `<= 0` with `ValueError("checkpoint interval must be a positive integer")`.
- Preserve the `unit` behavior and return a `CheckpointOption(interval=..., unit=...)` for valid inputs.
- Add parser tests `test_checkpoint_clause_invalid_intervals` to assert invalid intervals (`0`, `-1`, `2.5`) raise the expected `ValueError` and `test_compile_sql_includes_checkpoint_from_parsed_statement` to ensure the compile path still serializes `checkpoint_schedule` JSON unchanged for a valid parsed statement.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_parser.py -k checkpoint` and the checkpoint-focused tests passed (`4 passed, 45 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e291ccf37883289a3e7e17b24db24b)