### PR TITLE
Decode escaped DSL strings with json.loads in parser transformer

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -272,7 +272,7 @@ class TreeToModel(Transformer):
         return float(text) if "." in text else int(text)
 
     def ESCAPED_STRING(self, token):
-        return token.value.strip('"')
+        return json.loads(str(token))
 
     def value(self, items):
         return items[0]
@@ -365,7 +365,7 @@ class TreeToModel(Transformer):
 
     def feature_string(self, items):
         (value,) = items
-        return f'"{value}"'
+        return json.dumps(value)
 
     def feature_kwarg(self, items):
         name, value = items

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -280,6 +280,40 @@ class TestParser(unittest.TestCase):
             ],
         )
 
+    def test_algorithm_param_string_escapes_are_decoded(self):
+        text = (
+            'TRAIN MODEL m USING alg(name="a\\\\\\"b", note="line1\\\\nline2") FROM t '
+            "PREDICT y WITH FEATURES(a)"
+        )
+        model = cast(parser.TrainModel, parser.parse(text))
+        self.assertEqual(
+            model.params,
+            [
+                ("name", 'a\\"b'),
+                ("note", "line1\\nline2"),
+            ],
+        )
+
+    def test_algorithm_param_nested_literal_string_escapes_are_decoded(self):
+        text = (
+            "TRAIN MODEL m USING alg("
+            'config={label: "a\\\\\\"b", nested: ["line1\\\\nline2", {inner: "x\\\\\\"y"}]}'
+            ") FROM t PREDICT y WITH FEATURES(a)"
+        )
+        model = cast(parser.TrainModel, parser.parse(text))
+        self.assertEqual(
+            model.params,
+            [
+                (
+                    "config",
+                    {
+                        "label": 'a\\"b',
+                        "nested": ["line1\\nline2", {"inner": 'x\\"y'}],
+                    },
+                )
+            ],
+        )
+
     def test_negative_param_values(self):
         text = (
             "TRAIN MODEL m USING alg(alpha=-0.1, depth=-5) FROM t "


### PR DESCRIPTION
### Motivation

- Improve correctness of DSL string handling by properly decoding escape sequences (e.g. `"`, `\n`) rather than naively stripping quotes.

### Description

- Updated `TreeToModel.ESCAPED_STRING` in `dsl/parser.py` to decode tokens via `json.loads(str(token))` instead of `strip('"')` so escaped content is interpreted as runtime strings.
- Adjusted `TreeToModel.feature_string` to emit feature strings with `json.dumps(value)` to preserve correct escaping when feature expressions are re-parsed/compiled.
- Added tests in `tests/test_parser.py` to validate decoded escaped strings in algorithm params, including embedded quotes and newline escapes, and nested dict/list literal cases.
- Updated the existing feature-string test expectations to align with JSON-based decoding/encoding behavior end-to-end.

### Testing

- Ran `python -m pytest -q tests/test_parser.py` after the changes, which passed with `49 passed, 5 subtests passed`.
- Also executed a focused run of the new tests which reported `3 passed, 46 deselected` during development prior to the full-suite run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e291cbc4d88328aef7c9241f6eaaf8)