### PR TITLE
Refactor TRAIN source-clause grammar to avoid premature PREDICT termination

### DIFF
--- a/dsl/parser.py
+++ b/dsl/parser.py
@@ -14,10 +14,31 @@ dsl_grammar = r"""
 ?start: train_stmt
        | compute_stmt
 
-train_stmt: "TRAIN" "MODEL" NAME "USING" algorithm "FROM" sql_clause \
+train_stmt: "TRAIN" "MODEL" NAME "USING" algorithm "FROM" source_clause \
             "PREDICT" NAME features option*
 
-sql_clause: SQL_CLAUSE
+source_clause: source_atom+
+source_atom: NAME
+           | SIGNED_NUMBER
+           | ESCAPED_STRING
+           | SINGLE_QUOTED_STRING
+           | "."
+           | ","
+           | "("
+           | ")"
+           | "*"
+           | "+"
+           | "-"
+           | "/"
+           | "%"
+           | "="
+           | "!="
+           | "<>"
+           | "<="
+           | ">="
+           | "<"
+           | ">"
+           | ":"
 
 compute_stmt: "COMPUTE" NAME compute_from? compute_into? compute_every? \
               "USING" NAME kernel_opt*
@@ -111,11 +132,11 @@ COMP_OP: ">=" | "<=" | ">" | "<" | "!=" | "="
 %import common.WS
 %ignore WS
 
-SQL_CLAUSE: /(.|\n)+?(?=PREDICT\b)/
+SINGLE_QUOTED_STRING: /'(?:''|[^'])*'/
 """
 
 # instantiate the parser once at module import time
-_PARSER = Lark(dsl_grammar, start="start", parser="lalr")
+_PARSER = Lark(dsl_grammar, start="start", parser="lalr", propagate_positions=True)
 
 _FEATURE_EXPR_PARSER = Lark(
     r"""
@@ -264,6 +285,10 @@ class ComputeKernel:
 
 
 class TreeToModel(Transformer):
+    def __init__(self, source_text: str | None = None) -> None:
+        super().__init__()
+        self._source_text = source_text
+
     def NAME(self, token):
         return str(token)
 
@@ -377,10 +402,12 @@ class TreeToModel(Transformer):
     def name_list(self, items):
         return list(items)
 
-    def sql_clause(self, items):
-        token = items[0]
-        text = token.value if hasattr(token, "value") else str(token)
-        return text.strip()
+    @v_args(meta=True)
+    def source_clause(self, meta, items):
+        if self._source_text is not None:
+            return self._source_text[meta.start_pos : meta.end_pos].strip()
+
+        return " ".join(str(item) for item in items).strip()
 
     def compute_from(self, items):
         return ("inputs", items[0])
@@ -571,7 +598,7 @@ class TreeToModel(Transformer):
 def parse(text: str) -> TrainModel | ComputeKernel:
     tree = _PARSER.parse(text)
     try:
-        model = TreeToModel().transform(tree)
+        model = TreeToModel(source_text=text).transform(tree)
     except VisitError as e:
         if isinstance(e.orig_exc, ValueError):
             raise e.orig_exc

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -153,6 +153,32 @@ class TestParser(unittest.TestCase):
             sql_str,
         )
 
+    def test_parse_train_model_source_with_predict_in_string_literal(self):
+        text = (
+            "TRAIN MODEL filtered USING alg FROM transactions t "
+            "WHERE t.note = 'PREDICT' PREDICT y WITH FEATURES(a)"
+        )
+        model = cast(parser.TrainModel, parser.parse(text))
+        self.assertEqual(
+            model.source,
+            "transactions t WHERE t.note = 'PREDICT'",
+        )
+        self.assertEqual(model.target, "y")
+        self.assertFalse(model.source_is_identifier)
+
+    def test_parse_train_model_source_with_predict_in_alias(self):
+        text = (
+            "TRAIN MODEL filtered USING alg FROM (SELECT * FROM transactions) predict_alias "
+            "PREDICT y WITH FEATURES(a)"
+        )
+        model = cast(parser.TrainModel, parser.parse(text))
+        self.assertEqual(
+            model.source,
+            "(SELECT * FROM transactions) predict_alias",
+        )
+        self.assertEqual(model.target, "y")
+        self.assertFalse(model.source_is_identifier)
+
     def test_parse_train_model_with_options(self):
         text = (
             "TRAIN MODEL m USING alg() FROM data PREDICT y "


### PR DESCRIPTION
### Motivation
- The prior `SQL_CLAUSE` regex token terminated the FROM/source clause on the first textual `PREDICT`, which broke valid SQL containing the word `PREDICT` (e.g. inside string literals or aliases).
- The goal is to reliably distinguish the DSL `PREDICT` keyword from SQL text while preserving existing supported source forms (single identifiers, joins, parenthesized subqueries with alias).

### Description
- Replaced the fragile `SQL_CLAUSE` regex in `dsl/parser.py` with a structured `source_clause` grammar composed of `source_atom` tokens to safely tokenize source text instead of greedy regex capture.
- Added `SINGLE_QUOTED_STRING` token support so single-quoted SQL literals within the source clause are parsed as distinct tokens rather than triggering `PREDICT` termination.
- Enabled parser position propagation by creating the Lark parser with `propagate_positions=True` and updated the `TreeToModel` transformer to accept the original `source_text` and extract the source clause via the parse node `meta` slice, ensuring exact original text is preserved.
- Adjusted transformer `source_clause` to use metadata-aware extraction and updated `parse()` to pass the original DSL text; kept compatibility with existing `_is_identifier_source_clause`/_validate logic.
- Added regression tests that ensure `PREDICT` inside SQL string literals and alias names do not prematurely terminate the source clause (`test_parse_train_model_source_with_predict_in_string_literal` and `test_parse_train_model_source_with_predict_in_alias`).

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_parser.py` and received all tests passing: `49 passed, 5 subtests passed`.
- The new tests specifically added are `test_parse_train_model_source_with_predict_in_string_literal` and `test_parse_train_model_source_with_predict_in_alias` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e291cbc5788328ba00e0d150a32b69)